### PR TITLE
[GAL-22] Provisioning runtime verbose log is ignored with maven execution in debug mode

### DIFF
--- a/maven-plugins/src/main/java/org/jboss/galleon/maven/plugin/ProvisionStateMojo.java
+++ b/maven-plugins/src/main/java/org/jboss/galleon/maven/plugin/ProvisionStateMojo.java
@@ -39,6 +39,7 @@ import org.apache.maven.project.MavenProject;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.jboss.galleon.ArtifactCoords;
+import org.jboss.galleon.DefaultMessageWriter;
 import org.jboss.galleon.ProvisioningException;
 import org.jboss.galleon.ProvisioningManager;
 import org.jboss.galleon.config.FeaturePackConfig;
@@ -196,7 +197,9 @@ public class ProvisionStateMojo extends AbstractMojo {
         final ProvisioningManager pm = ProvisioningManager.builder()
                 .setArtifactResolver(
                         FeaturePackRepositoryManager.newInstance(repoSession.getLocalRepository().getBasedir().toPath()))
-                .setInstallationHome(installDir.toPath()).build();
+                .setInstallationHome(installDir.toPath())
+                .setMessageWriter(new DefaultMessageWriter(System.out, System.err, getLog().isDebugEnabled()))
+                .build();
 
         pm.provision(state.build(), pluginOptions);
     }


### PR DESCRIPTION
This patch enables the configuration of the provisioning runtime log according to the maven debug option.

Jira issue: https://issues.jboss.org/browse/GAL-22