### PR TITLE
Fix for GAL-51, make early initialization and installation to run concurrently safely

### DIFF
--- a/cli/src/main/java/org/jboss/galleon/cli/model/FeatureSpecsBuilder.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/model/FeatureSpecsBuilder.java
@@ -21,7 +21,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
 import java.nio.file.FileVisitResult;
 import static java.nio.file.FileVisitResult.CONTINUE;
 import java.nio.file.Files;
@@ -42,6 +41,7 @@ import org.jboss.galleon.runtime.ResolvedSpecId;
 import org.jboss.galleon.spec.FeatureSpec;
 import org.jboss.galleon.spec.PackageDependencySpec;
 import org.jboss.galleon.universe.FeaturePackLocation.FPID;
+import org.jboss.galleon.util.ZipUtils;
 import org.jboss.galleon.xml.FeatureSpecXmlParser;
 
 /**
@@ -73,9 +73,8 @@ public class FeatureSpecsBuilder {
         if (specs == null) {
             specs = new HashSet<>();
             final Set<FeatureSpecInfo> fSpecs = specs;
-            FileSystem fs = FileSystems.newFileSystem(session.getUniverse().
-                    getUniverseResolver().resolve(fpid.getLocation()), null);
-            try {
+            try (FileSystem fs = ZipUtils.newFileSystem(session.getUniverse().
+                    getUniverseResolver().resolve(fpid.getLocation()))) {
                 final Path path = fs.getPath("features/");
                 Files.walkFileTree(path, new SimpleFileVisitor<Path>() {
 
@@ -157,8 +156,6 @@ public class FeatureSpecsBuilder {
                         return CONTINUE;
                     }
                 });
-            } finally {
-                fs.close();
             }
             if (useCache) {
                 if (allSpecs == null) {

--- a/core/src/main/java/org/jboss/galleon/layout/FeaturePackLayoutDescriber.java
+++ b/core/src/main/java/org/jboss/galleon/layout/FeaturePackLayoutDescriber.java
@@ -21,7 +21,6 @@ import java.io.Reader;
 import java.nio.charset.Charset;
 import java.nio.file.DirectoryStream;
 import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -32,6 +31,7 @@ import org.jboss.galleon.Errors;
 import org.jboss.galleon.ProvisioningDescriptionException;
 import org.jboss.galleon.spec.FeaturePackSpec;
 import org.jboss.galleon.spec.PackageSpec;
+import org.jboss.galleon.util.ZipUtils;
 import org.jboss.galleon.xml.PackageXmlParser;
 import org.jboss.galleon.xml.XmlParsers;
 
@@ -46,7 +46,7 @@ import org.jboss.galleon.xml.XmlParsers;
 public class FeaturePackLayoutDescriber {
 
     public static FeaturePackLayout describeFeaturePackZip(Path artifactZip) throws IOException, ProvisioningDescriptionException {
-        try (FileSystem zipfs = FileSystems.newFileSystem(artifactZip, null)) {
+        try (FileSystem zipfs = ZipUtils.newFileSystem(artifactZip)) {
             for(Path zipRoot : zipfs.getRootDirectories()) {
                 return describeFeaturePack(zipRoot, "UTF-8");
             }

--- a/core/src/main/java/org/jboss/galleon/layout/ProvisioningLayoutFactory.java
+++ b/core/src/main/java/org/jboss/galleon/layout/ProvisioningLayoutFactory.java
@@ -95,7 +95,7 @@ public class ProvisioningLayoutFactory implements Closeable {
         return new ProvisioningLayout<>(this, config, factory);
     }
 
-    Path resolveFeaturePackDir(FeaturePackLocation fpl) throws ProvisioningException {
+    synchronized Path resolveFeaturePackDir(FeaturePackLocation fpl) throws ProvisioningException {
         final Path fpDir = LayoutUtils.getFeaturePackDir(home, fpl.getFPID(), false);
         if(Files.exists(fpDir)) {
             return fpDir;

--- a/core/src/main/java/org/jboss/galleon/util/HashUtils.java
+++ b/core/src/main/java/org/jboss/galleon/util/HashUtils.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
 import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
@@ -95,7 +94,7 @@ public class HashUtils {
     public static byte[] hashJar(Path jarFile, boolean ignoreManifest) throws IOException {
         synchronized (DIGEST) {
             DIGEST.reset();
-            try (FileSystem zipfs = FileSystems.newFileSystem(jarFile, null)) {
+            try (FileSystem zipfs = ZipUtils.newFileSystem(jarFile)) {
                 for (Path zipRoot : zipfs.getRootDirectories()) {
                     final Map<String, Path> sortedChildren = new TreeMap<String, Path>();
                     try(DirectoryStream<Path> stream = Files.newDirectoryStream(zipRoot)) {

--- a/core/src/main/java/org/jboss/galleon/util/ZipUtils.java
+++ b/core/src/main/java/org/jboss/galleon/util/ZipUtils.java
@@ -47,8 +47,8 @@ public class ZipUtils {
         if(!Files.exists(targetDir)) {
             Files.createDirectories(targetDir);
         }
-        try (FileSystem zipfs = FileSystems.newFileSystem(toZipUri(zipFile), Collections.emptyMap())) {
-            for(Path zipRoot : zipfs.getRootDirectories()) {
+        try (FileSystem zipfs = newFileSystem(zipFile)) {
+            for (Path zipRoot : zipfs.getRootDirectories()) {
                 copyFromZip(zipRoot, targetDir);
             }
         }
@@ -89,7 +89,7 @@ public class ZipUtils {
     }
 
     public static void zip(Path src, Path zipFile) throws IOException {
-        try (FileSystem zipfs = FileSystems.newFileSystem(toZipUri(zipFile), Files.exists(zipFile) ? Collections.emptyMap() : CREATE_ENV)) {
+        try (FileSystem zipfs = newFileSystem(toZipUri(zipFile), Files.exists(zipFile) ? Collections.emptyMap() : CREATE_ENV)) {
             if(Files.isDirectory(src)) {
                 try (DirectoryStream<Path> stream = Files.newDirectoryStream(src)) {
                     for(Path srcPath : stream) {
@@ -126,4 +126,29 @@ public class ZipUtils {
                     }
                 });
     }
+
+    /**
+     * This call is not thread safe, a single of FileSystem can be created for the
+     * profided uri until it is closed.
+     * @param uri The uri to the zip file.
+     * @param env Env map.
+     * @return A new FileSystem.
+     * @throws IOException
+     */
+    public static FileSystem newFileSystem(URI uri, Map<String, ?> env) throws IOException {
+        // If Multi threading required, logic should be added to wrap this fs
+        // onto a fs that handles a reference counter and close the fs only when all thread are done
+        // with it.
+        return FileSystems.newFileSystem(uri, env);
+    }
+
+    /**
+     * This call is thread safe, a new FS is created for each invocation.
+     * @param path The zip file.
+     * @return A new FileSystem instance
+     * @throws IOException
+     */
+     public static FileSystem newFileSystem(Path path) throws IOException {
+         return FileSystems.newFileSystem(path, null);
+     }
 }


### PR DESCRIPTION
1) Moved all usages of newFileSystem to ZipUtils. It allows for better control on newFileSystem calls.
2) Replaced calls to newFileSystem(URI) that can take a file path to newFileSystem(Path), this call is thread safe.
3) The remaining call (a single one) that takes an URI has not to be synchronized, could be made if needed (prototype of it not present in this PR).
3) Made producers and channels zip file extraction thread safe.
4) ProvisioningLayoutFactory.resolveFeaturePackDir synchronized to avoid concurrent unzip.

galleon-plugins (WfInstall plugin) should be updated to call into ZipUtils when creating new file system. Not strictly needed but would increase consistency.