### PR TITLE
[GAL-67] Allow maven provisioning plugin to locate feature packs using a file path

### DIFF
--- a/core/src/main/java/org/jboss/galleon/ArtifactCoords.java
+++ b/core/src/main/java/org/jboss/galleon/ArtifactCoords.java
@@ -38,7 +38,11 @@ public class ArtifactCoords implements Comparable<ArtifactCoords> {
     }
 
     public static ArtifactCoords fromString(String str) {
-        return new ArtifactCoords(str);
+        return new ArtifactCoords(str, "jar");
+    }
+
+    public static ArtifactCoords fromString(String str, String defaultExtension) {
+        return new ArtifactCoords(str, defaultExtension);
     }
 
     public static Gav newGav(String groupId, String artifactId, String version) {
@@ -261,7 +265,7 @@ public class ArtifactCoords implements Comparable<ArtifactCoords> {
     private final Gav gavPart;
     private final Ga gaPart;
 
-    private ArtifactCoords(String str) {
+    private ArtifactCoords(String str, String defaultExtension) {
         final Matcher m = COORDS_PATTERN.matcher(str);
         if (!m.matches()) {
             throw new IllegalArgumentException("Bad artifact coordinates " + str
@@ -269,7 +273,7 @@ public class ArtifactCoords implements Comparable<ArtifactCoords> {
         }
         groupId = m.group(1);
         artifactId = m.group(2);
-        extension = get(m.group(4), "jar");
+        extension = get(m.group(4), defaultExtension);
         classifier = get(m.group(6), "");
         version = m.group(7);
 

--- a/maven-plugin/src/main/java/org/jboss/galleon/maven/plugin/util/FeaturePack.java
+++ b/maven-plugin/src/main/java/org/jboss/galleon/maven/plugin/util/FeaturePack.java
@@ -17,6 +17,8 @@
 
 package org.jboss.galleon.maven.plugin.util;
 
+import java.io.File;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 
@@ -47,6 +49,8 @@ public class FeaturePack implements DependableCoordinate, ArtifactCoordinate {
     private boolean inheritPackages = true;
     private List<String> excludedPackages = Collections.emptyList();
     private List<String> includedPackages = Collections.emptyList();
+
+    private Path path;
 
     @Override
     public String getGroupId() {
@@ -173,6 +177,15 @@ public class FeaturePack implements DependableCoordinate, ArtifactCoordinate {
         this.includedPackages = includedPackages;
     }
 
+    public void setPath(File path) {
+        assertPathLocation();
+        this.path = path.toPath().normalize();
+    }
+
+    public Path getNormalizedPath() {
+        return path;
+    }
+
     @Override
     public String toString() {
         final StringBuilder buf = new StringBuilder();
@@ -206,15 +219,30 @@ public class FeaturePack implements DependableCoordinate, ArtifactCoordinate {
         return buf.append('}').toString();
     }
 
+    private void assertPathLocation() {
+        if (groupId != null || artifactId != null || version != null) {
+            throw new IllegalStateException("feature-pack Path cannot be used: Galleon 1.x feature-pack Maven coordinates have already been initialized");
+        }
+        if (location != null) {
+            throw new IllegalStateException("feature-pack Path cannot be used: Galleon 2.x location has already been initialized");
+        }
+    }
+
     private void assertGalleon2Location() {
         if(groupId != null || artifactId != null || version != null) {
             throw new IllegalStateException("Galleon 2.x location cannot be used: feature-pack Maven coordinates have already been initialized");
+        }
+        if (path != null) {
+            throw new IllegalStateException("Galleon 2.x location cannot be used: feature-pack Path has already been initialized");
         }
     }
 
     private void assertGalleon1Location() {
         if(location != null) {
             throw new IllegalStateException("Galleon 1.x feature-pack Maven coordinates cannot be used: Galleon 2.x feature-pack location has already been initialized");
+        }
+        if (path != null) {
+            throw new IllegalStateException("Galleon 1.x feature-pack Maven coordinates cannot be used: feature-pack Path has already been initialized");
         }
     }
 }

--- a/maven-plugin/src/main/java/org/jboss/galleon/maven/plugin/util/ResolveLocalArtifactItem.java
+++ b/maven-plugin/src/main/java/org/jboss/galleon/maven/plugin/util/ResolveLocalArtifactItem.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.galleon.maven.plugin.util;
+
+import org.apache.maven.shared.artifact.ArtifactCoordinate;
+import org.jboss.galleon.ArtifactCoords;
+import org.jboss.galleon.universe.maven.MavenArtifact;
+
+/**
+ * Represents an artifact inside of resolve-local section in resolve-locals parameter
+ * configuration of provisioning plugin.
+ * <p>
+ * Each artifact is a feature-pack based on maven coordinates that will be
+ * added as local feature pack.
+ */
+public class ResolveLocalArtifactItem implements ArtifactCoordinate {
+    private ArtifactCoords artifactCoords;
+
+    /**
+     * Default setter for maven parameter.
+     * Artifact in string format
+     *
+     * @parameter
+     */
+    public void set(String artifact) {
+        artifactCoords = ArtifactCoords.fromString(artifact, MavenArtifact.EXT_ZIP);
+    }
+
+    @Override
+    public String getGroupId() {
+        return artifactCoords != null ? artifactCoords.getGroupId() : null;
+    }
+
+    @Override
+    public String getArtifactId() {
+        return artifactCoords != null ? artifactCoords.getArtifactId() : null;
+    }
+
+    @Override
+    public String getVersion() {
+        return artifactCoords != null ? artifactCoords.getVersion() : null;
+    }
+
+    @Override
+    public String getExtension() {
+        return artifactCoords != null ? artifactCoords.getExtension() : null;
+    }
+
+    @Override
+    public String getClassifier() {
+        return artifactCoords != null ? artifactCoords.getClassifier() : null;
+    }
+}

--- a/maven-plugin/src/main/java/org/jboss/galleon/maven/plugin/util/ResolveLocalItem.java
+++ b/maven-plugin/src/main/java/org/jboss/galleon/maven/plugin/util/ResolveLocalItem.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.galleon.maven.plugin.util;
+
+import java.io.File;
+import java.nio.file.Path;
+
+/**
+ * Represents the information of each item inside of resolve-locals configuration param for
+ * provisioning plugin.
+ */
+public class ResolveLocalItem {
+    private Path path;
+    private ResolveLocalArtifactItem artifact;
+    private Boolean installInUniverse;
+    /**
+     * Even throwing an exception if there is a wrong configuration for this element,
+     * the error is silently ignored and the build continues. We use this text field here
+     * to flag that the configuration has an error.
+     */
+    private String error;
+
+    /**
+     * File pointing to a feature-pack
+     *
+     * @parameter
+     * @param file
+     *
+     * @throws IllegalStateException if artifact has been already initialized
+     */
+    public void setPath(File file) {
+        assertPath();
+        this.path = file.toPath().normalize();
+        this.installInUniverse = installInUniverse == null ? Boolean.TRUE : installInUniverse;
+    }
+
+    public Path getNormalizedPath(){
+        return path;
+    }
+
+    /**
+     * Artifact string using groupId:artifactId:version format
+     *
+     * @parameter
+     * @param artifact
+     *
+     * @throws IllegalStateException if Path or install-in-universe have been already initialized
+     */
+    public void setArtifact(ResolveLocalArtifactItem artifact) {
+        assertArtifact();
+        this.artifact = artifact;
+        this.installInUniverse = Boolean.FALSE;
+    }
+
+    public ResolveLocalArtifactItem getArtifact() {
+        return artifact;
+    }
+
+    /**
+     * Boolean value for install-in-universe parameter configuration
+     *
+     * @parameter
+     * @param installInUniverse
+     */
+    public void setInstallInUniverse(Boolean installInUniverse) {
+        assertInstallInUniverse();
+        this.installInUniverse = installInUniverse;
+    }
+
+    public Boolean getInstallInUniverse() {
+        return installInUniverse;
+    }
+
+    private void assertArtifact() {
+        if (this.path != null || installInUniverse != null) {
+            error = "feature-pack artifact cannot be used: feature-pack Path or install-in-universe have already been initialized";
+            throw new IllegalStateException(error);
+        }
+    }
+
+    private void assertPath() {
+        if (this.artifact != null) {
+            error = "feature-pack Path cannot be used: feature-pack artifact has already been initialized";
+            throw new IllegalStateException(error);
+        }
+    }
+
+    private void assertInstallInUniverse() {
+        if (this.artifact != null) {
+            error = "feature-pack install-in-universe cannot be used: feature-pack artifact has already been initialized";
+            throw new IllegalStateException(error);
+        }
+    }
+
+    public String getError() {
+        return error;
+    }
+}


### PR DESCRIPTION
This patch allows specifying a feature pack path in the provisioning plugin, additionally, the feature pack dependencies can be specified using a GAV or a path to a file. These configurations will allow resolving feature packs without using Universe.

Jira issue: https://issues.jboss.org/browse/GAL-67