### PR TITLE
Fix for GAL-75 and doc

### DIFF
--- a/cli/src/main/java/org/jboss/galleon/cli/AbstractStateCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/AbstractStateCommand.java
@@ -25,6 +25,7 @@ import org.aesh.command.option.Option;
 import org.aesh.readline.AeshContext;
 import org.jboss.galleon.ProvisioningException;
 import org.jboss.galleon.ProvisioningManager;
+import org.jboss.galleon.cli.cmd.CommandWithInstallationDirectory;
 import org.jboss.galleon.cli.model.FeatureContainer;
 import org.jboss.galleon.cli.model.FeatureContainers;
 import org.jboss.galleon.config.ProvisioningConfig;
@@ -34,7 +35,7 @@ import org.jboss.galleon.runtime.ProvisioningRuntime;
  *
  * @author jdenise@redhat.com
  */
-public abstract class AbstractStateCommand extends PmSessionCommand {
+public abstract class AbstractStateCommand extends PmSessionCommand implements CommandWithInstallationDirectory {
 
     public static class DirActivator extends PmOptionActivator {
 
@@ -55,10 +56,11 @@ public abstract class AbstractStateCommand extends PmSessionCommand {
     }
 
     protected ProvisioningManager getManager(PmSession session) throws ProvisioningException {
-        return session.newProvisioningManager(getTargetDir(session.getAeshContext()), false);
+        return session.newProvisioningManager(getInstallationDirectory(session.getAeshContext()), false);
     }
 
-    protected Path getTargetDir(AeshContext context) {
+    @Override
+    public Path getInstallationDirectory(AeshContext context) {
         Path workDir = PmSession.getWorkDir(context);
         return targetDirArg == null ? PmSession.getWorkDir(context) : workDir.resolve(targetDirArg);
     }

--- a/cli/src/main/java/org/jboss/galleon/cli/PmSession.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/PmSession.java
@@ -270,6 +270,10 @@ public class PmSession implements CommandInvocationProvider<PmCommandInvocation>
                 || location.endsWith("" + FeaturePackLocation.BUILD_START)) {
             location = location.substring(0, location.length() - 1);
         }
+        // A producer spec without any universe nor channel.
+        if (!location.contains("" + FeaturePackLocation.UNIVERSE_START) && !location.contains("" + FeaturePackLocation.CHANNEL_START)) {
+            location = new FeaturePackLocation(universe.getDefaultUniverseSpec(), location, null, null, null).toString();
+        }
         FeaturePackLocation loc = FeaturePackLocation.fromString(location);
         return getResolvedLocation(loc);
     }

--- a/cli/src/main/java/org/jboss/galleon/cli/ProvisioningCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/ProvisioningCommand.java
@@ -24,12 +24,13 @@ import org.jboss.galleon.ProvisioningException;
 import org.jboss.galleon.ProvisioningManager;
 import static org.jboss.galleon.cli.AbstractStateCommand.DIR_OPTION_NAME;
 import static org.jboss.galleon.cli.AbstractStateCommand.VERBOSE_OPTION_NAME;
+import org.jboss.galleon.cli.cmd.CommandWithInstallationDirectory;
 
 /**
  *
  * @author Alexey Loubyansky
  */
-public abstract class ProvisioningCommand extends PmSessionCommand {
+public abstract class ProvisioningCommand extends PmSessionCommand implements CommandWithInstallationDirectory {
 
     @Option(name = DIR_OPTION_NAME, completer = FileOptionCompleter.class, required = false,
             description="Target installation directory.")
@@ -39,12 +40,13 @@ public abstract class ProvisioningCommand extends PmSessionCommand {
             description = "Whether or not the output should be verbose")
     boolean verbose;
 
-    protected Path getTargetDir(AeshContext context) {
+    @Override
+    public Path getInstallationDirectory(AeshContext context) {
         Path workDir = PmSession.getWorkDir(context);
         return targetDirArg == null ? PmSession.getWorkDir(context) : workDir.resolve(targetDirArg);
     }
 
     protected ProvisioningManager getManager(PmCommandInvocation session) throws ProvisioningException {
-        return session.getPmSession().newProvisioningManager(getTargetDir(session.getAeshContext()), verbose);
+        return session.getPmSession().newProvisioningManager(getInstallationDirectory(session.getAeshContext()), verbose);
     }
 }

--- a/cli/src/main/java/org/jboss/galleon/cli/UninstallCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/UninstallCommand.java
@@ -20,6 +20,7 @@ import org.aesh.command.CommandDefinition;
 import org.aesh.command.option.Argument;
 import org.jboss.galleon.ProvisioningException;
 import org.jboss.galleon.cli.cmd.CliErrors;
+import org.jboss.galleon.cli.cmd.InstalledFPLCompleter;
 import org.jboss.galleon.cli.cmd.state.NoStateCommandActivator;
 import org.jboss.galleon.universe.FeaturePackLocation.FPID;
 
@@ -30,7 +31,7 @@ import org.jboss.galleon.universe.FeaturePackLocation.FPID;
 @CommandDefinition(name = "uninstall", description = "Uninstalls specified feature-pack", activator = NoStateCommandActivator.class)
 public class UninstallCommand extends ProvisioningCommand {
 
-    @Argument(completer = InstalledStreamCompleter.class)
+    @Argument(completer = InstalledFPLCompleter.class)
     protected String streamName;
 
     @Override

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/AbstractCommaSeparatedCompleter.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/AbstractCommaSeparatedCompleter.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.galleon.cli.cmd;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import org.jboss.galleon.cli.AbstractCompleter;
+import org.jboss.galleon.cli.PmCompleterInvocation;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+public abstract class AbstractCommaSeparatedCompleter extends AbstractCompleter {
+
+    @Override
+    public void complete(PmCompleterInvocation completerInvocation) {
+        List<String> candidates = new ArrayList<>();
+        List<String> all = getItems(completerInvocation);
+        if (all.isEmpty()) {
+            return;
+        }
+        String buffer = completerInvocation.getGivenCompleteValue();
+        candidates.addAll(all);
+        int offset = 0;
+        if (!buffer.isEmpty()) {
+            List<String> specified = Arrays.asList(buffer.split(",+"));
+
+            if (buffer.charAt(buffer.length() - 1) != ',') {
+                String chunk = specified.get(specified.size() - 1);
+                boolean needsComma = candidates.contains(chunk);
+                candidates.removeAll(specified);
+                if (candidates.isEmpty()) {
+                    candidates.add(chunk);
+                    completerInvocation.setAppendSpace(true);
+                    completerInvocation.setOffset(chunk.length());
+                } else {
+                    final Iterator<String> iterator = candidates.iterator();
+                    boolean hasMore = false;
+                    while (iterator.hasNext()) {
+                        if (!iterator.next().startsWith(chunk)) {
+                            hasMore = true;
+                            iterator.remove();
+                        }
+                    }
+                    if (candidates.isEmpty() && hasMore && needsComma) {
+                        candidates.add(chunk + ",");
+                    }
+                    offset = buffer.length() - chunk.length();
+                    completerInvocation.setOffset(chunk.length());
+                    completerInvocation.setAppendSpace(!hasMore);
+                }
+            } else {
+                candidates.removeAll(specified);
+                if (candidates.size() == 1) {
+                    completerInvocation.setOffset(0);
+                }
+            }
+        }
+        completerInvocation.addAllCompleterValues(candidates);
+
+    }
+}

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/CommandWithInstallationDirectory.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/CommandWithInstallationDirectory.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.galleon.cli.cmd;
+
+import java.nio.file.Path;
+import org.aesh.readline.AeshContext;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+public interface CommandWithInstallationDirectory {
+
+    Path getInstallationDirectory(AeshContext ctx);
+}

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/InstalledFPLCompleter.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/InstalledFPLCompleter.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.galleon.cli;
+package org.jboss.galleon.cli.cmd;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -23,32 +23,32 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.jboss.galleon.ProvisioningManager;
+import org.jboss.galleon.cli.AbstractCompleter;
+import org.jboss.galleon.cli.PmCompleterInvocation;
 import org.jboss.galleon.config.FeaturePackConfig;
 
 /**
- * Installed streams completer. XXX TODO, for now complete FP GAV.
+ * Installed FPL completer. XXX jfdenise, we shouldn't require it when uninstall
+ * accepts producer.
  *
  * @author jdenise@redhat.com
  */
-public class InstalledStreamCompleter extends AbstractCompleter {
+public class InstalledFPLCompleter extends AbstractCompleter {
 
     @Override
     protected List<String> getItems(PmCompleterInvocation completerInvocation) {
-        ProvisioningCommand cmd = (ProvisioningCommand) completerInvocation.getCommand();
-        Path currentDir = cmd.getTargetDir(completerInvocation.getAeshContext());
+        CommandWithInstallationDirectory cmd = (CommandWithInstallationDirectory) completerInvocation.getCommand();
+        Path currentDir = cmd.getInstallationDirectory(completerInvocation.getAeshContext());
         List<String> items = new ArrayList<>();
         try {
             ProvisioningManager.checkInstallationDir(currentDir);
             ProvisioningManager mgr = completerInvocation.getPmSession().
                     newProvisioningManager(currentDir, false);
             for (FeaturePackConfig fp : mgr.getProvisioningConfig().getFeaturePackDeps()) {
-                if(fp.getLocation().getBuild() == null) {
-                    continue;
-                }
-                items.add(fp.getLocation().toString());
+                items.add(completerInvocation.getPmSession().getExposedLocation(fp.getLocation()).toString());
             }
         } catch (Exception ex) {
-            Logger.getLogger(InstalledStreamCompleter.class.getName()).log(Level.FINEST,
+            Logger.getLogger(InstalledProducerCompleter.class.getName()).log(Level.FINEST,
                     "Exception while completing: {0}", ex.getLocalizedMessage());
         }
         return items;

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/InstalledProducerCompleter.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/InstalledProducerCompleter.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.galleon.cli.cmd;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.jboss.galleon.ProvisioningManager;
+import org.jboss.galleon.cli.PmCompleterInvocation;
+import org.jboss.galleon.config.FeaturePackConfig;
+
+/**
+ * Installed producer completer.
+ *
+ * @author jdenise@redhat.com
+ */
+public class InstalledProducerCompleter extends AbstractCommaSeparatedCompleter {
+
+    @Override
+    protected List<String> getItems(PmCompleterInvocation completerInvocation) {
+        CommandWithInstallationDirectory cmd = (CommandWithInstallationDirectory) completerInvocation.getCommand();
+        Path currentDir = cmd.getInstallationDirectory(completerInvocation.getAeshContext());
+        List<String> items = new ArrayList<>();
+        try {
+            ProvisioningManager.checkInstallationDir(currentDir);
+            ProvisioningManager mgr = completerInvocation.getPmSession().
+                    newProvisioningManager(currentDir, false);
+            for (FeaturePackConfig fp : mgr.getProvisioningConfig().getFeaturePackDeps()) {
+                items.add(completerInvocation.getPmSession().getExposedLocation(fp.getLocation()).getProducer().toString());
+            }
+        } catch (Exception ex) {
+            Logger.getLogger(InstalledProducerCompleter.class.getName()).log(Level.FINEST,
+                    "Exception while completing: {0}", ex.getLocalizedMessage());
+        }
+        return items;
+    }
+
+}

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/plugin/AbstractProvisionWithPlugins.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/plugin/AbstractProvisionWithPlugins.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.galleon.cli.cmd.plugin;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.aesh.command.impl.completer.FileOptionCompleter;
+import org.aesh.command.impl.internal.OptionType;
+import org.aesh.command.impl.internal.ProcessedOption;
+import org.aesh.command.impl.internal.ProcessedOptionBuilder;
+import org.aesh.command.parser.OptionParserException;
+import org.aesh.readline.AeshContext;
+import org.jboss.galleon.ProvisioningException;
+import org.jboss.galleon.ProvisioningManager;
+import static org.jboss.galleon.cli.AbstractStateCommand.DIR_OPTION_NAME;
+import static org.jboss.galleon.cli.AbstractStateCommand.VERBOSE_OPTION_NAME;
+import org.jboss.galleon.cli.CliMain;
+import org.jboss.galleon.cli.CommandExecutionException;
+import org.jboss.galleon.cli.PmCommandActivator;
+import org.jboss.galleon.cli.PmCommandInvocation;
+import org.jboss.galleon.cli.PmSession;
+import org.jboss.galleon.cli.cmd.AbstractDynamicCommand;
+import org.jboss.galleon.cli.cmd.state.NoStateCommandActivator;
+import org.jboss.galleon.cli.cmd.CommandWithInstallationDirectory;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+public abstract class AbstractProvisionWithPlugins extends AbstractDynamicCommand implements CommandWithInstallationDirectory {
+
+    protected AbstractProvisionWithPlugins(PmSession pmSession) {
+        super(pmSession, true, false, CliMain.experimentalFeaturesEnabled());
+    }
+
+    @Override
+    protected String getId(PmSession session) throws CommandExecutionException {
+        // We can't cache anything.
+        return null;
+    }
+
+    protected abstract List<ProcessedOption> getOtherOptions() throws OptionParserException;
+
+    @Override
+    protected List<ProcessedOption> getStaticOptions() throws OptionParserException {
+        List<ProcessedOption> options = new ArrayList<>();
+        options.add(ProcessedOptionBuilder.builder().name(DIR_OPTION_NAME).
+                hasValue(true).
+                type(String.class).
+                optionType(OptionType.NORMAL).
+                description("Target installation directory.").
+                completer(FileOptionCompleter.class).
+                build());
+        options.add(ProcessedOptionBuilder.builder().name(VERBOSE_OPTION_NAME).
+                hasValue(false).
+                type(Boolean.class).
+                description("Whether or not the output should be verbose").
+                optionType(OptionType.BOOLEAN).
+                build());
+        options.addAll(getOtherOptions());
+        return options;
+    }
+
+    protected boolean isVerbose() {
+        return contains(VERBOSE_OPTION_NAME);
+    }
+
+    protected String getDir() {
+        return (String) getValue(DIR_OPTION_NAME);
+    }
+
+    protected ProvisioningManager getManager(PmCommandInvocation session) throws ProvisioningException {
+        return session.getPmSession().newProvisioningManager(getInstallationDirectory(session.getAeshContext()), isVerbose());
+    }
+
+    @Override
+    public Path getInstallationDirectory(AeshContext context) {
+        return getDir() == null ? PmSession.getWorkDir(context) : getAbsolutePath(getDir(), context);
+    }
+
+    protected Path getAbsolutePath(String path, AeshContext context) {
+        Path workDir = PmSession.getWorkDir(context);
+        return path == null ? PmSession.getWorkDir(context) : workDir.resolve(path);
+    }
+
+    protected abstract void doRunCommand(PmCommandInvocation session, Map<String, String> options) throws CommandExecutionException;
+
+    @Override
+    protected void runCommand(PmCommandInvocation session, Map<String, String> options) throws CommandExecutionException {
+        if (isVerbose()) {
+            session.getPmSession().enableMavenTrace(true);
+        }
+        try {
+            doRunCommand(session, options);
+        } finally {
+            session.getPmSession().enableMavenTrace(false);
+        }
+    }
+
+    @Override
+    protected PmCommandActivator getActivator() {
+        return new NoStateCommandActivator();
+    }
+}

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/plugin/DiffCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/plugin/DiffCommand.java
@@ -44,6 +44,8 @@ import org.jboss.galleon.universe.FeaturePackLocation;
  *
  * @author jdenise@redhat.com
  */
+// Can be removed/refactored when we know what to do with it.
+@Deprecated
 public class DiffCommand extends AbstractPluginsCommand {
 
     private static final String SRC_NAME = "src";

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/state/StateCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/state/StateCommand.java
@@ -29,7 +29,6 @@ import org.aesh.command.impl.registry.AeshCommandRegistryBuilder;
 import org.aesh.command.parser.CommandLineParserException;
 import org.jboss.galleon.cli.PmCommandInvocation;
 import org.jboss.galleon.cli.PmSession;
-import org.jboss.galleon.cli.cmd.plugin.DiffCommand;
 import org.jboss.galleon.cli.cmd.state.configuration.ConfigCommand;
 import org.jboss.galleon.cli.cmd.state.fp.FPCommand;
 import org.jboss.galleon.cli.cmd.state.pkg.PackageCommand;
@@ -41,11 +40,11 @@ import org.jboss.galleon.cli.cmd.state.pkg.PackageCommand;
 @GroupCommandDefinition(description = "", name = "state")
 public class StateCommand implements GroupCommand<PmCommandInvocation, Command> {
 
-    private final DiffCommand diffCommand;
+    private final StateUpgradeCommand upgradeCommand;
     private final StateProvisionCommand provisionCommand;
     public StateCommand(PmSession pmSession) {
-        this.diffCommand = new DiffCommand(pmSession);
         this.provisionCommand = new StateProvisionCommand(pmSession);
+        this.upgradeCommand = new StateUpgradeCommand(pmSession);
     }
 
     @Override
@@ -57,7 +56,7 @@ public class StateCommand implements GroupCommand<PmCommandInvocation, Command> 
     @Override
     public List<CommandContainer<Command<PmCommandInvocation>, PmCommandInvocation>> getParsedCommands() throws CommandLineParserException {
         List<CommandContainer<Command<PmCommandInvocation>, PmCommandInvocation>> commands = new ArrayList<>();
-        commands.add(diffCommand.createCommand());
+        commands.add(upgradeCommand.createCommand());
         commands.add(provisionCommand.createCommand());
         return commands;
     }
@@ -78,7 +77,6 @@ public class StateCommand implements GroupCommand<PmCommandInvocation, Command> 
         commands.add(new StateExploreCommand());
         commands.add(new StateExportCommand());
         commands.add(new StateLeaveCommand());
-        commands.add(new StateUpgradeCommand());
         return commands;
     }
 

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/state/StateInfoUtil.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/state/StateInfoUtil.java
@@ -338,7 +338,7 @@ public class StateInfoUtil {
         }
         if (!plugins.getInstall().isEmpty()) {
             found = true;
-            builder.append("Diff command options").append(Config.getLineSeparator());
+            builder.append("Upgrade command options").append(Config.getLineSeparator());
             builder.append(buildOptionsTable(plugins.getDiff()));
         }
         if (found) {

--- a/docs/guide/tool/state.adoc
+++ b/docs/guide/tool/state.adoc
@@ -1,11 +1,103 @@
 ## Galleon CLI tool
-A set of commands is offered to observe, explore, edit, diff, export, provision or create a new provisioning state.
+This command line tool (_bin/galleon.[sh|bat]_) allows you to provision/manage any products/installations that comply with galleon feature-packs.
+Although being a generic tool, a builtin support is offered for products available from maven jboss community universe (eg: wildfly). +
+Possible actions that you can operate from the tool: install, uninstall, check for updates, patch, upgrade.
+
+### Feature-pack
+A key concept in galleon system is the notion of feature-pack. A feature-pack is a content container. It can be a full product (eg: wildfly) 
+or part of a product (eg: a wildfly subsystem packaged as a feature-pack). With the tool you are going to install/uninstall/upgrade/... feature-packs. +
+NB: A galleon installation can be composed of 1 or more feature-packs.
+
+A feature-pack can be a file on your local file system or located inside a universe (a product catalog).
+
+The tool helps you identify the feature-pack that you can use for the task you want to achieve. In order to take benefit of the full capabilities
+offered by the tool, one needs to understand how products are identified inside a universe.
+
+### Universe feature-pack location (FPL)
+A feature-pack location (FPL) is the way to identify a product inside a universe without actually expressing any build numbers. 
+A lot to commands require that you provide FPL. 
+
+The main (non exhaustive) FPL syntax is: _<product>[@universe]:[version]/[qualifier]_ +
+Some examples of FPL to identify wildfly products:
+
+* _wildfly:current_ ==> Final (released) wildfly product current version
+* _wildfly:current/alpha_ ==> The latest release of wildfly product current version that is at least of alpha quality.
+
+The things to notice:
+
+* Universe (from where the product comes from) is optional for products located in jboss maven community universe.
+* No actual version nor build (eg: 1.0.0-Alpha1-SNAPHOT) is provided. The syntax of FPL is abstract it allows you to express a level of expected quality without
+hard-coding any version number.
+* Pointed by an FPL is an actual feature-pack artifact (a zipped file) that the tool will download/install,...
+* A completer helps you compose FPL when the command you are calling expect one (eg: install).
+ 
+For example, if one installs wildfly product using the following command:
+
+_install wildfly:current/alpha --dir=myInstallation_ 
+
+Then, later, when checking for updates or upgrading _myInstallation_ directory, 
+the latest build that is at least of quality alpha will be used to update. 
+If a final release is available then it will be installed when upgrading.
+
+NB: Products being unique inside an installation, some commands (eg: _state upgrade_) 
+only require the product part (_<product>[@universe]_) of an FPL. For example:
+
+_state upgrade --products=wildfly_
+
+### Universe feature-pack id (FPID)
+A feature-pack id (FPID) is the way to identify a product inside a universe by expressing a build number. 
+This is the syntax to use when you want to deal with specific builds of a product.
+
+The FPID syntax is: _<product>[@universe]:[version]#[buildID]_ +
+Some examples of FPID to identify wildfly products:
+
+* _wildfly:current#1.0.0-Final_
+* _wildfly:current#1.0.0-Alpha1_
+
+The things to notice:
+
+* Universe (from where the poduct comes from) is optional for products located in jboss maven community universe.
+* Pointed by an FPID is an actual feature-pack artifact (a zipped file)
+* A completer helps you compose your FPID when the command you are calling expect one (eg: install).
+ 
+For example, to retrieve the informations of alpha1 build:
+
+_feature-pack info wildfly:current#1.0.0-Alpha1_ 
+
 
 ### Installing a feature-pack
 
-_install <[FPL] | [--file=<path to fp zip file>]> [--dir=<installation dir>] [--verbose] [list of discovered feature-pack options]_
+_install <[FPL|FPID] | [--file=<path to fp zip file>]> [--dir=<installation dir>] [--verbose] [feature-pack specific options]_
 
-This creates a directory containing the installed feature-pack content (binaries, configs).
+This creates a directory containing the installed feature-pack content (binaries, configs). +
+NB: To retrieve the set of feature-pack specific options call: +
+_feature-pack info <[FPL|FPID] | [--file=<path to fp zip file>]> --type=options_ +
+You can then use the listed options (if any) to customize your installation.
+
+### Un-installing a feature-pack
+
+_uninstall [FPID] [--dir=<installation dir>]_
+
+This will remove the content installed by the feature-pack identified by the FPID.
+
+### Patching an installation
+
+Use the _install_ command to patch an existing installation.
+
+_install [--file=<path to patch fp zip file>]> [--dir=<installation dir>] [--verbose] [feature-pack specific options]_
+
+### Checking for updates
+
+_state check-updates [--dir=<installation dir>] [--include-all-dependencies] [--products=<list of products>]_
+
+If no directory is provided, the current directory is used. If no products are provided, all installed products are checked for updates.
+
+### Upgrading an installation
+
+_state upgrade [--dir=<installation dir> [--include-all-dependencies] [--yes] [--products=<list of products>] [list of discovered feature-pack options]_
+
+Display the ist of available updates/patches then upgrade. If no directory is provided, the current directory is used. 
+If _--yes_ is provided, the command will proceed without asking for confirmation.
 
 ### Observing an installation
 
@@ -15,9 +107,9 @@ Display the set of dependencies and/or configurations and/or applied patches. Al
 
 ### Observing a feature-pack
 
-_[my-dir]$ feature-pack info <[FPL] | [--file=<path to fp zip file>]> --type=[configs|dependencies]_
+_[my-dir]$ feature-pack info <[FPL|FPID] | [--file=<path to fp zip file>]> --type=[configs|dependencies|options]_
 
-Display the set of dependencies and/or configurations. All is displayed by default.
+Display the set of dependencies and/or configurations and/or options usable when installing/provisioning/upgrading. All is displayed by default.
 
 ### Exporting an installation to xml
 
@@ -33,7 +125,7 @@ To explore an installation: +
 _[my-dir]$ state explore --dir=installation_ +
 
 To explore a feature-pack: +
-_[my-dir]$ feature-pack explore <[FPL] | [--file=<path to fp zip file>]_ +
+_[my-dir]$ feature-pack explore <[FPL|FPID] | [--file=<path to fp zip file>]_ +
 
 Once exploring, prompt, ls, cd and pwd commands are bound to the feature-pack (or installation) exposed file-system. +
 
@@ -121,7 +213,7 @@ TIP: The command state info can be used to get high level information.
 
 ### Adding a feature-pack
 
-_[/]$ fp add <stream | --fp=coords> [--default-configs-inherit] [--packages-inherit]_ +
+_[/]$ fp add <FPL|FPID> [--default-configs-inherit] [--packages-inherit]_ +
 
 By default nothing is inherited. Once at least one feature-pack has been added, configurations or packages can be handled. 
 
@@ -129,17 +221,17 @@ NB: A runtime based on the added full feature-pack is built in order to retrieve
 
 ### Removing a feature-pack
 
-_[/]$ fp remove <fpcoord for now>_
+_[/]$ fp remove <FPL|FPID>_
 
 ### Including a default configuration
 
-_[/]$ config include <model>/<name> [--origin=<fp coords>]_
+_[/]$ config include <model>/<name> [--origin=<fp origin>]_
 
 Origin is optional, by default will be included from all fp that expose it.
 
 ### Removing an included default configuration
 
-_[/]$ config remove-included <model>/<name> [--origin=<fp coords>]_
+_[/]$ config remove-included <model>/<name> [--origin=<fp origin>]_
 
 The completer only proposes the set of configurations that have been previously included. Same for fp.
 Origin is optional, by default will be remove from all fp that include it.
@@ -147,13 +239,13 @@ Origin is optional, by default will be remove from all fp that include it.
 
 ### Excluding a default configuration
 
-_[/]$ config exclude <model>/<name> [--origin=<fp coords>]_
+_[/]$ config exclude <model>/<name> [--origin=<fp origin>]_
 
 Origin is optional, by default will be excluded from all fp that expose it.
 
 ### Removing an excluded default configuration
 
-_[/]$ config remove-excluded <model>/<name> [--origin=<fp coords>]_
+_[/]$ config remove-excluded <model>/<name> [--origin=<fp origin>]_
 
 The completer only proposes the set of configurations that have been previously excluded. Same for fp.
 Origin is optional, by default will be remove from all fp that exclude it.
@@ -169,22 +261,22 @@ NB: This has no effect on included/excluded configurations.
 
 ### Including a default package
 
-_[/]$ packages include <fpcoord for now>/<package name>_
+_[/]$ packages include <fp origin>/<package name>_
 
 ### Removing an included default package
 
-_[/]$ packages remove-included <package name> [--origin=<fp coords>]_
+_[/]$ packages remove-included <package name> [--origin=<fp origin>]_
 
 The completer only proposes the set of packages that have been previously included.
 The origin is optional, the package will be removed from all fp that exclude it.
 
 ### Excluding a default package
 
-_[/]$ packages exclude <fpcoord for now>/<package name>_
+_[/]$ packages exclude <fp origin>/<package name>_
 
 ### Removing an excluded default package
 
-_[/]$ packages remove-excluded <package name> [--origin=<fp coords>]_
+_[/]$ packages remove-excluded <package name> [--origin=<fp origin>]_
 
 The completer only proposes the set of packages that have been previously excluded.
 The origin is optional, the package will be removed from all fp that exclude it.
@@ -194,7 +286,7 @@ The origin is optional, the package will be removed from all fp that exclude it.
 _[/]$ feature add <config model/name> <path to feature-spec>  <dynamic set of feature param=<value>>_
 
 For example: +
-_feature add standalone/standalone.xml org.wildfly.core:wildfly-core-feature-pack-new/interface --interface=toto --inet-address=127.0.0.1_
+_feature add standalone/standalone.xml org.wildfly.core:wildfly-core-galleon-pack/interface --interface=toto --inet-address=127.0.0.1_
 
 NB: All parameters are exposed as command option.
  


### PR DESCRIPTION
- upgrade command to accept plugin options
- --products=<comma separated list of installed producerSpec> added to check-updates and upgrade commands.
- diff command is hidden. Keeping impl for reference and possible future usage. 
- test of identified producer upgrade.
- tool documentation to introduce FPL|FPID and general concepts. Added doc for upgrade.
