### PR TITLE
Fix for GAL-86, CLI progress tracking

### DIFF
--- a/cli/src/main/java/org/jboss/galleon/cli/PmSessionCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/PmSessionCommand.java
@@ -31,14 +31,14 @@ public abstract class PmSessionCommand implements Command<PmCommandInvocation> {
     @Override
     public CommandResult execute(PmCommandInvocation session) throws CommandException {
         try {
-            session.getPmSession().commandStart();
+            session.getPmSession().commandStart(session);
             runCommand(session);
             return CommandResult.SUCCESS;
         } catch (Throwable t) {
             handleException(session, t);
             return CommandResult.FAILURE;
         } finally {
-            session.getPmSession().commandEnd();
+            session.getPmSession().commandEnd(session);
         }
     }
 

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/AbstractDynamicCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/AbstractDynamicCommand.java
@@ -223,6 +223,7 @@ public abstract class AbstractDynamicCommand extends MapCommand<PmCommandInvocat
     @Override
     public CommandResult execute(PmCommandInvocation session) throws CommandException {
         try {
+            session.getPmSession().commandStart(session);
             validateOptions(session);
             Map<String, String> options = getOptions();
             runCommand(session, options);
@@ -230,6 +231,8 @@ public abstract class AbstractDynamicCommand extends MapCommand<PmCommandInvocat
         } catch (Throwable t) {
             PmSessionCommand.handleException(session, t);
             return CommandResult.FAILURE;
+        } finally {
+            session.getPmSession().commandEnd(session);
         }
     }
 

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/state/StateNewCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/state/StateNewCommand.java
@@ -44,7 +44,7 @@ public class StateNewCommand extends PmSessionCommand {
         }
         invoc.getPmSession().setState(session);
         invoc.setPrompt(PmSession.buildPrompt(invoc.getPmSession().getState().getPath()));
-        invoc.println("Entering provisioning composition mode. Use 'feature-pack add' command to add content. Call 'leave' to leave this mode.");
+        invoc.println("Entering provisioning composition mode. Use 'fp add' command to add content. Call 'leave' to leave this mode.");
     }
 
 }

--- a/cli/src/main/java/org/jboss/galleon/cli/tracking/BuildLayoutTracker.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/tracking/BuildLayoutTracker.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.galleon.cli.tracking;
+
+import org.jboss.galleon.cli.PmSession;
+import org.jboss.galleon.progresstracking.ProgressTracker;
+import org.jboss.galleon.universe.FeaturePackLocation.FPID;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+public class BuildLayoutTracker extends CliProgressTracker<FPID> {
+
+    private final PmSession session;
+
+    public BuildLayoutTracker(PmSession session) {
+        super("Resolving feature-pack", "Feature-packs resolved.");
+        this.session = session;
+    }
+
+    @Override
+    protected String processingContent(ProgressTracker<FPID> tracker) {
+        return session.getExposedLocation(tracker.getItem().getLocation()).toString();
+    }
+
+    @Override
+    protected String completeContent(ProgressTracker<FPID> tracker) {
+        return "";
+    }
+
+}

--- a/cli/src/main/java/org/jboss/galleon/cli/tracking/CliProgressTracker.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/tracking/CliProgressTracker.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.galleon.cli.tracking;
+
+import org.aesh.utils.ANSI;
+import org.aesh.utils.Config;
+import org.jboss.galleon.cli.PmCommandInvocation;
+import org.jboss.galleon.progresstracking.ProgressCallback;
+import org.jboss.galleon.progresstracking.ProgressTracker;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+abstract class CliProgressTracker<T> implements ProgressCallback<T> {
+
+    final String msgStart;
+    final String msgComplete;
+    PmCommandInvocation invocation;
+
+    CliProgressTracker(String msgStart, String msgComplete) {
+        this.msgStart = msgStart;
+        this.msgComplete = msgComplete;
+    }
+
+    void commandStart(PmCommandInvocation invocation) {
+        this.invocation = invocation;
+    }
+
+    void commandEnd(PmCommandInvocation invocation) {
+        this.invocation = invocation;
+    }
+
+    void print(String content) {
+        invocation.getShell().write(ANSI.CURSOR_SAVE);
+        invocation.getShell().write(ANSI.ERASE_WHOLE_LINE);
+        invocation.getShell().write(content);
+        invocation.getShell().write(ANSI.CURSOR_RESTORE);
+    }
+
+    @Override
+    public void starting(ProgressTracker<T> tracker) {
+        print(msgStart);
+    }
+
+    // each time a new item is processed let's display it.
+    // this seems to be the more efficient way to create a lively output.
+    @Override
+    public void processing(ProgressTracker<T> tracker) {
+        String content = processingContent(tracker);
+        if (content != null) {
+            print(msgStart + " " + content);
+        }
+    }
+
+    @Override
+    public void pulse(ProgressTracker<T> tracker) {
+        // NO-OP.
+    }
+
+    @Override
+    public void complete(ProgressTracker<T> tracker) {
+        if (msgComplete != null) {
+            String content = completeContent(tracker);
+            print(msgComplete + (content == null ? "" : " " + content) + Config.getLineSeparator());
+        } else {
+            // Simply erase the whole line, some content will come next
+            // and will re-use the current line to print some content.
+            invocation.getShell().write(ANSI.ERASE_WHOLE_LINE);
+        }
+    }
+
+    protected abstract String processingContent(ProgressTracker<T> tracker);
+
+    protected abstract String completeContent(ProgressTracker<T> tracker);
+
+}

--- a/cli/src/main/java/org/jboss/galleon/cli/tracking/ConfigsTracker.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/tracking/ConfigsTracker.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.galleon.cli.tracking;
+
+import org.jboss.galleon.progresstracking.ProgressTracker;
+import org.jboss.galleon.state.ProvisionedConfig;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+public class ConfigsTracker extends CliProgressTracker<ProvisionedConfig> {
+
+    public ConfigsTracker() {
+        super("Generating configuration", "Configurations generated.");
+    }
+
+    @Override
+    protected String processingContent(ProgressTracker<ProvisionedConfig> tracker) {
+        return tracker.getItem().getModel() + "/" + tracker.getItem().getName();
+    }
+
+    @Override
+    protected String completeContent(ProgressTracker<ProvisionedConfig> tracker) {
+        return "";
+    }
+
+}

--- a/cli/src/main/java/org/jboss/galleon/cli/tracking/PackagesTracker.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/tracking/PackagesTracker.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.galleon.cli.tracking;
+
+import org.jboss.galleon.progresstracking.ProgressTracker;
+import org.jboss.galleon.runtime.PackageRuntime;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+public class PackagesTracker extends CliProgressTracker<PackageRuntime> {
+
+    public PackagesTracker() {
+        super("Installing packages", "Packages installed.");
+    }
+
+    @Override
+    public String processingContent(ProgressTracker<PackageRuntime> tracker) {
+        return String.format("%s of %s packages installed (%s%%)",
+                tracker.getProcessedVolume(), tracker.getTotalVolume(), ((double) Math.round(tracker.getProgress() * 10)) / 10);
+    }
+
+    @Override
+    protected String completeContent(ProgressTracker<PackageRuntime> tracker) {
+        return "";
+    }
+}

--- a/cli/src/main/java/org/jboss/galleon/cli/tracking/ProgressTrackers.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/tracking/ProgressTrackers.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.galleon.cli.tracking;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import org.jboss.galleon.cli.PmCommandInvocation;
+import org.jboss.galleon.cli.PmSession;
+import org.jboss.galleon.layout.ProvisioningLayoutFactory;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+public abstract class ProgressTrackers {
+
+    private static final Map<String, CliProgressTracker<?>> trackers = new HashMap<>();
+    private ProgressTrackers() {
+    }
+
+    public static void registerTrackers(PmSession session) {
+        init(session);
+        for (Entry<String, CliProgressTracker<?>> entry : trackers.entrySet()) {
+            session.getLayoutFactory().setProgressCallback(entry.getKey(), entry.getValue());
+        }
+    }
+
+    public static void unregisterTrackers(PmSession session) {
+        for (Entry<String, CliProgressTracker<?>> entry : trackers.entrySet()) {
+            session.getLayoutFactory().setProgressCallback(entry.getKey(), null);
+        }
+    }
+
+    public static void commandStart(PmCommandInvocation session) {
+        init(session.getPmSession());
+        for (CliProgressTracker<?> tracker : trackers.values()) {
+            tracker.commandStart(session);
+        }
+    }
+
+    public static void commandEnd(PmCommandInvocation session) {
+        init(session.getPmSession());
+        for (CliProgressTracker<?> tracker : trackers.values()) {
+            tracker.commandEnd(session);
+        }
+    }
+
+    private static void init(PmSession session) {
+        if (trackers.isEmpty()) {
+            ProvisioningLayoutFactory factory = session.getLayoutFactory();
+            BuildLayoutTracker layout = new BuildLayoutTracker(session);
+            trackers.put(ProvisioningLayoutFactory.TRACK_LAYOUT_BUILD, layout);
+
+            PackagesTracker packages = new PackagesTracker();
+            trackers.put(ProvisioningLayoutFactory.TRACK_PACKAGES, packages);
+
+            ConfigsTracker configs = new ConfigsTracker();
+            trackers.put(ProvisioningLayoutFactory.TRACK_CONFIGS, configs);
+
+            UpdatesTracker updates = new UpdatesTracker(session);
+            trackers.put(ProvisioningLayoutFactory.TRACK_UPDATES, updates);
+        }
+    }
+}

--- a/cli/src/main/java/org/jboss/galleon/cli/tracking/UpdatesTracker.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/tracking/UpdatesTracker.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.galleon.cli.tracking;
+
+import org.jboss.galleon.cli.PmSession;
+import org.jboss.galleon.progresstracking.ProgressTracker;
+import org.jboss.galleon.universe.FeaturePackLocation.ProducerSpec;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+public class UpdatesTracker extends CliProgressTracker<ProducerSpec> {
+
+    private final PmSession session;
+
+    public UpdatesTracker(PmSession session) {
+        super("Looking for update for", null);
+        this.session = session;
+    }
+
+    @Override
+    protected String processingContent(ProgressTracker<ProducerSpec> tracker) {
+        return session.getExposedLocation(tracker.getItem().getLocation()).toString();
+    }
+
+    @Override
+    protected String completeContent(ProgressTracker<ProducerSpec> tracker) {
+        // No complete message, the command itself adds one.
+        return null;
+    }
+
+}

--- a/core/src/main/java/org/jboss/galleon/layout/ProvisioningLayoutFactory.java
+++ b/core/src/main/java/org/jboss/galleon/layout/ProvisioningLayoutFactory.java
@@ -85,7 +85,11 @@ public class ProvisioningLayoutFactory implements Closeable {
     }
 
     public void setProgressCallback(String id, ProgressCallback<?> callback) {
-        progressCallbacks = CollectionUtils.put(progressCallbacks, id, callback);
+        if (callback == null) {
+            progressCallbacks = CollectionUtils.remove(progressCallbacks, id);
+        } else {
+            progressCallbacks = CollectionUtils.put(progressCallbacks, id, callback);
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/testsuite/src/test/java/org/jboss/galleon/cli/CliWrapper.java
+++ b/testsuite/src/test/java/org/jboss/galleon/cli/CliWrapper.java
@@ -53,6 +53,7 @@ public class CliWrapper {
         runtime = CliMain.newRuntime(session, new PrintStream(out));
         session.getUniverse().disableBackgroundResolution();
         session.throwException();
+        session.enableTrackers(false);
         session.getPmConfiguration().getMavenConfig().setLocalRepository(mvnRepo.toPath());
     }
 


### PR DESCRIPTION
- Lively, informative and compact output to track progress from an high level point of view.
- Tracking enabled by default. Disabled in verbose mode.
- Cover all current tracking capabilities of galleon core (Build Layout, Updates, Packages, Configs).