### PR TITLE
Fix for GAL-81, minimize patch related information. Reworked state info

### DIFF
--- a/cli/src/main/java/org/jboss/galleon/cli/AbstractStateCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/AbstractStateCommand.java
@@ -16,6 +16,7 @@
  */
 package org.jboss.galleon.cli;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
@@ -65,7 +66,8 @@ public abstract class AbstractStateCommand extends PmSessionCommand implements C
         return targetDirArg == null ? PmSession.getWorkDir(context) : workDir.resolve(targetDirArg);
     }
 
-    public FeatureContainer getFeatureContainer(PmSession session) throws ProvisioningException, Exception {
+    public FeatureContainer getFeatureContainer(PmSession session) throws ProvisioningException,
+            CommandExecutionException, IOException {
         if (session.getContainer() != null) {
             return session.getContainer();
         }
@@ -80,5 +82,17 @@ public abstract class AbstractStateCommand extends PmSessionCommand implements C
             container = FeatureContainers.fromProvisioningRuntime(session, runtime);
         }
         return container;
+    }
+
+    protected ProvisioningConfig getProvisioningConfig(PmSession session) throws ProvisioningException, CommandExecutionException {
+        if (session.getContainer() != null) {
+            return session.getContainer().getProvisioningConfig();
+        }
+        ProvisioningManager manager = getManager(session);
+
+        if (manager.getProvisionedState() == null) {
+            throw new CommandExecutionException("Specified directory doesn't contain an installation");
+        }
+        return manager.getProvisioningConfig();
     }
 }

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/CliErrors.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/CliErrors.java
@@ -82,6 +82,10 @@ public interface CliErrors {
         return "Invalid history limit " + limit;
     }
 
+    static String invalidInfoType() {
+        return "Invalid info type";
+    }
+
     static String invalidUniverse() {
         return "Invalid universe";
     }

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/featurepack/InfoCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/featurepack/InfoCommand.java
@@ -30,6 +30,7 @@ import org.jboss.galleon.cli.PmCommandInvocation;
 import org.jboss.galleon.cli.PmCompleterInvocation;
 import org.jboss.galleon.cli.PmSession;
 import org.jboss.galleon.cli.cmd.CliErrors;
+import static org.jboss.galleon.cli.cmd.state.InfoTypeCompleter.ALL;
 import org.jboss.galleon.cli.cmd.state.StateInfoUtil;
 import org.jboss.galleon.cli.model.ConfigInfo;
 import static org.jboss.galleon.cli.path.FeatureContainerPathConsumer.CONFIGS;
@@ -58,7 +59,7 @@ public class InfoCommand extends AbstractFeaturePackCommand {
         @Override
         protected List<String> getItems(PmCompleterInvocation completerInvocation) {
             // No patch for un-customized FP.
-            return Arrays.asList(CONFIGS, DEPENDENCIES, OPTIONS);
+            return Arrays.asList(ALL, CONFIGS, DEPENDENCIES, OPTIONS);
         }
 
     }
@@ -119,12 +120,14 @@ public class InfoCommand extends AbstractFeaturePackCommand {
                 commandInvocation.println(PATCH_FOR + patchFor);
             }
             try {
-                if (type == null) {
-                    displayDependencies(commandInvocation, dependencies);
-                    displayConfigs(commandInvocation, product);
-                    displayOptions(commandInvocation, layout);
-                } else {
+                if (type != null) {
                     switch (type) {
+                        case ALL: {
+                            displayDependencies(commandInvocation, dependencies);
+                            displayConfigs(commandInvocation, product);
+                            displayOptions(commandInvocation, layout);
+                            break;
+                        }
                         case CONFIGS: {
                             displayConfigs(commandInvocation, product);
                             break;
@@ -136,6 +139,9 @@ public class InfoCommand extends AbstractFeaturePackCommand {
                         case OPTIONS: {
                             displayOptions(commandInvocation, layout);
                             break;
+                        }
+                        default: {
+                            throw new CommandExecutionException(CliErrors.invalidInfoType());
                         }
                     }
                 }

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/state/InfoTypeCompleter.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/state/InfoTypeCompleter.java
@@ -24,16 +24,18 @@ import java.util.List;
 
 import org.jboss.galleon.cli.AbstractCompleter;
 import org.jboss.galleon.cli.PmCompleterInvocation;
-import static org.jboss.galleon.cli.path.FeatureContainerPathConsumer.PATCHES;
 
 /**
  *
  * @author jdenise@redhat.com
  */
 public class InfoTypeCompleter extends AbstractCompleter {
+
+    public static final String ALL = "all";
+
     @Override
     protected List<String> getItems(PmCompleterInvocation completerInvocation) {
-        return Arrays.asList(CONFIGS, DEPENDENCIES, PATCHES);
+        return Arrays.asList(ALL, CONFIGS, DEPENDENCIES);
     }
 
 }

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/state/StateCheckUpdatesCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/state/StateCheckUpdatesCommand.java
@@ -32,6 +32,7 @@ import org.jboss.galleon.cli.cmd.CliErrors;
 import org.jboss.galleon.cli.cmd.Headers;
 import org.jboss.galleon.cli.cmd.Table;
 import org.jboss.galleon.cli.cmd.Table.Cell;
+import static org.jboss.galleon.cli.cmd.state.StateInfoUtil.DEFAULT_UNIVERSE;
 import org.jboss.galleon.layout.FeaturePackUpdatePlan;
 import org.jboss.galleon.layout.ProvisioningPlan;
 import org.jboss.galleon.universe.FeaturePackLocation;
@@ -137,7 +138,7 @@ public class StateCheckUpdatesCommand extends AbstractStateCommand {
             if (includeAll) {
                 line.add(new Cell(p.isTransitive() ? "Y" : "N"));
             }
-            line.add(new Cell((u == null ? "default" : u.toString())));
+            line.add(new Cell((u == null ? DEFAULT_UNIVERSE : u.toString())));
             t.addCellsLine(line);
         }
         t.sort(Table.SortType.ASCENDANT);

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/state/configuration/AbstractDefaultConfigCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/state/configuration/AbstractDefaultConfigCommand.java
@@ -49,7 +49,7 @@ public abstract class AbstractDefaultConfigCommand extends AbstractFPProvisioned
         private final FeatureContainer container;
 
         AllConfigsContainer(FeatureContainer container) {
-            super(null, null);
+            super(null, null, container.getProvisioningConfig());
             this.container = container;
         }
 

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/state/feature/StateAddFeatureCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/state/feature/StateAddFeatureCommand.java
@@ -61,7 +61,7 @@ public class StateAddFeatureCommand extends AbstractDynamicCommand {
         private final FeatureContainer container;
 
         AllFeaturesContainer(FeatureContainer container) {
-            super(null, null);
+            super(null, null, container.getProvisioningConfig());
             this.container = container;
         }
 

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/state/pkg/AbstractPackageCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/state/pkg/AbstractPackageCommand.java
@@ -50,7 +50,7 @@ public abstract class AbstractPackageCommand extends AbstractFPProvisionedComman
         private final FeatureContainer container;
 
         public AllPackagesContainer(FeatureContainer container) {
-            super(null, null);
+            super(null, null, container.getProvisioningConfig());
             this.container = container;
         }
 

--- a/cli/src/main/java/org/jboss/galleon/cli/config/mvn/MavenConfig.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/config/mvn/MavenConfig.java
@@ -32,6 +32,7 @@ import org.eclipse.aether.RepositoryListener;
 import org.eclipse.aether.RepositorySystem;
 import org.jboss.galleon.ArtifactException;
 import org.jboss.galleon.ProvisioningException;
+import static org.jboss.galleon.cli.CliMavenArtifactRepositoryManager.DEFAULT_REPOSITORY_TYPE;
 import org.jboss.galleon.util.PropertyUtils;
 import org.jboss.galleon.xml.util.FormattingXmlStreamWriter;
 
@@ -44,8 +45,8 @@ public class MavenConfig {
     private static final List<MavenRemoteRepository> DEFAULT_REPOSITORIES = new ArrayList<>();
     static {
         DEFAULT_REPOSITORIES.add(new MavenRemoteRepository("jboss-public-repository-group",
-                "default", "http://repository.jboss.org/nexus/content/groups/public/"));
-        DEFAULT_REPOSITORIES.add(new MavenRemoteRepository("maven-central", "default",
+                DEFAULT_REPOSITORY_TYPE, "http://repository.jboss.org/nexus/content/groups/public/"));
+        DEFAULT_REPOSITORIES.add(new MavenRemoteRepository("maven-central", DEFAULT_REPOSITORY_TYPE,
                 "http://repo1.maven.org/maven2/"));
     }
     public interface MavenChangeListener {

--- a/cli/src/main/java/org/jboss/galleon/cli/model/FeatureContainer.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/model/FeatureContainer.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.jboss.galleon.config.FeaturePackConfig;
+import org.jboss.galleon.config.ProvisioningConfig;
 
 import org.jboss.galleon.runtime.ResolvedSpecId;
 import org.jboss.galleon.universe.FeaturePackLocation.FPID;
@@ -46,10 +47,16 @@ public abstract class FeatureContainer {
     private Map<ResolvedSpecId, FeatureSpecInfo> allSpecs;
     private Map<Identity, Group> allPackages;
     private Map<ResolvedSpecId, List<FeatureInfo>> allFeatures;
+    private final ProvisioningConfig config;
 
-    protected FeatureContainer(String name, FPID fpid) {
+    protected FeatureContainer(String name, FPID fpid, ProvisioningConfig config) {
         this.name = name;
         this.fpid = fpid;
+        this.config = config;
+    }
+
+    public ProvisioningConfig getProvisioningConfig() {
+        return config;
     }
 
     void addDependency(FPID fpid, FeaturePackConfig config) {

--- a/cli/src/main/java/org/jboss/galleon/cli/model/FeatureContainers.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/model/FeatureContainers.java
@@ -59,8 +59,8 @@ public abstract class FeatureContainers {
         if (fp != null) {
             return fp;
         }
-        fp = new FeaturePackInfo(name, fpid);
         try (ProvisioningRuntime rt = buildFullRuntime(fpid, session)) {
+            fp = new FeaturePackInfo(name, fpid, rt.getProvisioningConfig());
             populateFeatureContainer(fp, session, rt, true);
             Caches.addFeaturePackInfo(fpid, fp);
         }
@@ -69,7 +69,7 @@ public abstract class FeatureContainers {
 
     public static FeatureContainer fromProvisioningRuntime(PmSession session,
             ProvisioningRuntime runtime) throws ProvisioningException, IOException {
-        ProvisioningInfo info = new ProvisioningInfo();
+        ProvisioningInfo info = new ProvisioningInfo(runtime.getProvisioningConfig());
         populateFeatureContainer(info, session, runtime, false);
         return info;
     }
@@ -80,7 +80,8 @@ public abstract class FeatureContainers {
         Map<String, FeaturePackRuntime> gavs = new HashMap<>();
         for (FeaturePackRuntime rt : runtime.getFeaturePacks()) {
             gavs.put(Identity.buildOrigin(rt.getFPID().getProducer()), rt);
-            FeaturePackConfig config = runtime.getProvisioningConfig().getFeaturePackDep(rt.getFPID().getProducer());
+            // Can be null if no transitive dep declared.
+            FeaturePackConfig config = runtime.getProvisioningConfig().getTransitiveDep(rt.getFPID().getProducer());
             fp.addDependency(rt.getFPID(), config);
         }
         List<CliPlugin> cliPlugins = new ArrayList<>();

--- a/cli/src/main/java/org/jboss/galleon/cli/model/FeaturePackInfo.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/model/FeaturePackInfo.java
@@ -16,6 +16,7 @@
  */
 package org.jboss.galleon.cli.model;
 
+import org.jboss.galleon.config.ProvisioningConfig;
 import org.jboss.galleon.universe.FeaturePackLocation.FPID;
 
 /**
@@ -26,8 +27,8 @@ public class FeaturePackInfo extends FeatureContainer {
 
     private final String description;
 
-    FeaturePackInfo(String name, FPID fpid) {
-        super(name, fpid);
+    FeaturePackInfo(String name, FPID fpid, ProvisioningConfig config) {
+        super(name, fpid, config);
         this.description = "No Description available yet";
     }
     /**

--- a/cli/src/main/java/org/jboss/galleon/cli/model/ProvisioningInfo.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/model/ProvisioningInfo.java
@@ -16,13 +16,15 @@
  */
 package org.jboss.galleon.cli.model;
 
+import org.jboss.galleon.config.ProvisioningConfig;
+
 /**
  *
  * @author jdenise@redhat.com
  */
 public class ProvisioningInfo extends FeatureContainer {
 
-    ProvisioningInfo() {
-        super(null, null);
+    ProvisioningInfo(ProvisioningConfig config) {
+        super(null, null, config);
     }
 }

--- a/cli/src/main/java/org/jboss/galleon/cli/path/FeatureContainerPathConsumer.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/path/FeatureContainerPathConsumer.java
@@ -54,7 +54,6 @@ public class FeatureContainerPathConsumer implements PathConsumer {
     public static final String DEPENDENCIES = "dependencies";
     public static final String PACKAGES = "packages";
     public static final String CONFIGS = "configs";
-    public static final String PATCHES = "patches";
     public static final String FINAL = "final";
     public static final String OPTIONS = "options";
     public static final String ROOT = "" + PathParser.PATH_SEPARATOR;

--- a/docs/guide/tool/state.adoc
+++ b/docs/guide/tool/state.adoc
@@ -107,15 +107,17 @@ If _--yes_ is provided, the command will proceed without asking for confirmation
 
 ### Observing an installation
 
-_[my-dir]$ state info [--dir=installation] --type=[configs|dependencies|patches]_
+_[my-dir]$ state info [--dir=installation] --type=[all|configs|dependencies]_
 
-Display the set of dependencies and/or configurations and/or applied patches. All is displayed by default.
+Display the set of installed feature-packs FPID. In addition can display configurations and dependencies. + 
+NB: If some patches are applied, the patch information is displayed.
 
 ### Observing a feature-pack
 
-_[my-dir]$ feature-pack info <[FPL|FPID] | [--file=<path to fp zip file>]> --type=[configs|dependencies|options]_
+_[my-dir]$ feature-pack info <[FPL|FPID] | [--file=<path to fp zip file>]> --type=[all|configs|dependencies|options]_
 
-Display the set of dependencies and/or configurations and/or options usable when installing/provisioning/upgrading. All is displayed by default.
+Display the FPID of a feature-pack. In addition can display dependencies, configurations 
+and options usable when installing/provisioning/upgrading.
 
 ### Exporting an installation to xml
 

--- a/testsuite/src/test/java/org/jboss/galleon/cli/PatchTestCase.java
+++ b/testsuite/src/test/java/org/jboss/galleon/cli/PatchTestCase.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import org.aesh.command.CommandException;
 import static org.jboss.galleon.cli.CliTestUtils.PRODUCER1;
 import static org.jboss.galleon.cli.CliTestUtils.UNIVERSE_NAME;
+import org.jboss.galleon.cli.cmd.Headers;
 import org.jboss.galleon.cli.cmd.featurepack.InfoCommand;
 import org.jboss.galleon.config.FeaturePackConfig;
 import org.jboss.galleon.config.ProvisioningConfig;
@@ -59,6 +60,9 @@ public class PatchTestCase {
         Path install1 = CliTestUtils.installAndCheck(cli, "install1", CliTestUtils.buildFPL(universeSpec, PRODUCER1, "1", "snapshot", null),
                 CliTestUtils.buildFPL(universeSpec, PRODUCER1, "1", "snapshot", "1.0.0.Alpha1"));
 
+        // No patches information
+        Assert.assertFalse(cli.getOutput(), cli.getOutput().contains(Headers.PATCHES));
+
         Path patchDir = cli.newDir("patches", true);
         FPID patchID = CliTestUtils.installPatch(cli, universeSpec, PRODUCER1, "1.0.0", "Alpha1", patchDir);
         Path patchFile = patchDir.toFile().listFiles()[0].toPath();
@@ -89,6 +93,7 @@ public class PatchTestCase {
 
         //Check that output contains the patch.
         cli.execute("state info --dir=" + install1);
+        Assert.assertTrue(cli.getOutput(), cli.getOutput().contains(Headers.PATCHES));
         Assert.assertTrue(cli.getOutput(), cli.getOutput().contains(patchID.getBuild()));
 
         // uninstall the patch

--- a/testsuite/src/test/java/org/jboss/galleon/cli/PatchTransitiveDepTestCase.java
+++ b/testsuite/src/test/java/org/jboss/galleon/cli/PatchTransitiveDepTestCase.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.galleon.cli;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import org.jboss.galleon.ProvisioningException;
+import static org.jboss.galleon.cli.CliTestUtils.PRODUCER1;
+import static org.jboss.galleon.cli.CliTestUtils.PRODUCER2;
+import static org.jboss.galleon.cli.CliTestUtils.UNIVERSE_NAME;
+import org.jboss.galleon.creator.FeaturePackCreator;
+import org.jboss.galleon.universe.FeaturePackLocation;
+import org.jboss.galleon.universe.MvnUniverse;
+import org.jboss.galleon.universe.UniverseSpec;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+public class PatchTransitiveDepTestCase {
+    private static UniverseSpec universeSpec;
+    private static CliWrapper cli;
+    private static MvnUniverse universe;
+    private static FeaturePackLocation fp1;
+    private static FeaturePackLocation fp1Patch;
+    private static FeaturePackLocation fp2;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        cli = new CliWrapper();
+        universe = MvnUniverse.getInstance(UNIVERSE_NAME, cli.getSession().getMavenRepoManager());
+        universeSpec = CliTestUtils.setupUniverse(universe, cli, UNIVERSE_NAME, Arrays.asList(PRODUCER1, PRODUCER2));
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        cli.close();
+    }
+
+    @Test
+    public void test() throws Exception {
+        install();
+        Path p = CliTestUtils.installAndCheck(cli, "install", fp2, fp2);
+        cli.execute("state info --dir=" + p);
+        Assert.assertFalse(cli.getOutput(), cli.getOutput().contains(PRODUCER1));
+        Assert.assertTrue(cli.getOutput(), cli.getOutput().contains(PRODUCER2));
+
+        cli.execute("state info --dir=" + p + " --type=all");
+        Assert.assertTrue(cli.getOutput(), cli.getOutput().contains(PRODUCER1));
+        Assert.assertTrue(cli.getOutput(), cli.getOutput().contains(PRODUCER2));
+
+        cli.execute("install " + fp1Patch + " --dir=" + p);
+
+        cli.execute("state info --dir=" + p);
+        Assert.assertFalse(cli.getOutput(), cli.getOutput().contains("1.0.0.Patch.Final"));
+
+        cli.execute("state info --dir=" + p + " --type=dependencies");
+        Assert.assertTrue(cli.getOutput(), cli.getOutput().contains("1.0.0.Patch.Final"));
+    }
+
+    private static void install() throws ProvisioningException {
+        FeaturePackCreator creator = FeaturePackCreator.getInstance().addArtifactResolver(cli.getSession().getMavenRepoManager());
+        fp1 = new FeaturePackLocation(universeSpec,
+                PRODUCER1, "1", null, "1.0.0.Final");
+        creator.newFeaturePack(fp1.getFPID())
+                .newPackage("p1", true)
+                .writeContent("fp1/p1.txt", "fp1 p1");
+
+        fp1Patch = new FeaturePackLocation(universeSpec,
+                PRODUCER1, "1", null, "1.0.0.Patch.Final");
+        creator.newFeaturePack(fp1Patch.getFPID())
+                .setPatchFor(fp1.getFPID())
+                .newPackage("p1", true)
+                .writeContent("fp1/p1.txt", "fp1 p1 patch");
+
+        fp2 = new FeaturePackLocation(universeSpec,
+                PRODUCER2, "1", null, "1.0.0.Final");
+        creator.newFeaturePack(fp2.getFPID())
+                .addDependency(fp1);
+
+        creator.install();
+    }
+}


### PR DESCRIPTION
- No more 'patches' type of info, patches displayed when appropriate.
- Seperate installed vs dependencies. 
- Introduced all type to display all, by default only display installed (fast).
- New unit test for transitive dependency patching info.