### PR TITLE
Fix for GAL-96, better support for transitive dependencies.

### DIFF
--- a/cli/src/main/java/org/jboss/galleon/cli/AbstractStateCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/AbstractStateCommand.java
@@ -30,6 +30,7 @@ import org.jboss.galleon.cli.cmd.CommandWithInstallationDirectory;
 import org.jboss.galleon.cli.model.FeatureContainer;
 import org.jboss.galleon.cli.model.FeatureContainers;
 import org.jboss.galleon.config.ProvisioningConfig;
+import org.jboss.galleon.layout.ProvisioningLayout;
 import org.jboss.galleon.runtime.ProvisioningRuntime;
 
 /**
@@ -66,7 +67,7 @@ public abstract class AbstractStateCommand extends PmSessionCommand implements C
         return targetDirArg == null ? PmSession.getWorkDir(context) : workDir.resolve(targetDirArg);
     }
 
-    public FeatureContainer getFeatureContainer(PmSession session) throws ProvisioningException,
+    public FeatureContainer getFeatureContainer(PmSession session, ProvisioningLayout<ProvisioningLayout.FeaturePackLayout> layout) throws ProvisioningException,
             CommandExecutionException, IOException {
         if (session.getContainer() != null) {
             return session.getContainer();
@@ -77,9 +78,15 @@ public abstract class AbstractStateCommand extends PmSessionCommand implements C
         if (manager.getProvisionedState() == null) {
             throw new CommandExecutionException("Specified directory doesn't contain an installation");
         }
-        ProvisioningConfig config = manager.getProvisioningConfig();
-        try (ProvisioningRuntime runtime = manager.getRuntime(config, Collections.emptyMap())) {
-            container = FeatureContainers.fromProvisioningRuntime(session, runtime);
+        if (layout == null) {
+            ProvisioningConfig config = manager.getProvisioningConfig();
+            try (ProvisioningRuntime runtime = manager.getRuntime(config, Collections.emptyMap())) {
+                container = FeatureContainers.fromProvisioningRuntime(session, runtime);
+            }
+        } else {
+            try (ProvisioningRuntime runtime = manager.getRuntime(layout, Collections.emptyMap())) {
+                container = FeatureContainers.fromProvisioningRuntime(session, runtime);
+            }
         }
         return container;
     }

--- a/cli/src/main/java/org/jboss/galleon/cli/PmSession.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/PmSession.java
@@ -217,6 +217,10 @@ public class PmSession implements CommandInvocationProvider<PmCommandInvocation>
         enableTrackers = enable;
     }
 
+    public boolean isTrackersEnabled() {
+        return enableTrackers;
+    }
+
     private void registerTrackers() {
         ProgressTrackers.registerTrackers(this);
     }
@@ -280,6 +284,8 @@ public class PmSession implements CommandInvocationProvider<PmCommandInvocation>
             } else {
                 registerTrackers();
             }
+        } else {
+            unregisterTrackers();
         }
         return new DefaultMessageWriter(out, err, verbose);
     }

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/AbstractCommaSeparatedCompleter.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/AbstractCommaSeparatedCompleter.java
@@ -59,7 +59,7 @@ public abstract class AbstractCommaSeparatedCompleter extends AbstractCompleter 
                             iterator.remove();
                         }
                     }
-                    if (candidates.isEmpty() && hasMore && needsComma) {
+                    if (needsComma) {
                         candidates.add(chunk + ",");
                     }
                     offset = buffer.length() - chunk.length();

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/Headers.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/Headers.java
@@ -22,7 +22,7 @@ package org.jboss.galleon.cli.cmd;
  */
 public class Headers {
     public static final String BUILD = "Build";
-    public static final String CHANNEL = "Channel";
+    public static final String CHANNEL = "Update Channel";
     public static final String CONFIGURATION = "Configuration";
     public static final String CONFIGURATION_ITEM = "Configuration Item";
     public static final String CURRENT_BUILD = "Current Build";

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/InstalledFPLCompleter.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/InstalledFPLCompleter.java
@@ -56,7 +56,7 @@ public class InstalledFPLCompleter extends AbstractCompleter {
                 }
             }
         } catch (Exception ex) {
-            Logger.getLogger(InstalledProducerCompleter.class.getName()).log(Level.FINEST,
+            Logger.getLogger(InstalledFPLCompleter.class.getName()).log(Level.FINEST,
                     "Exception while completing: {0}", ex.getLocalizedMessage());
         }
         return items;

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/state/StateExploreCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/state/StateExploreCommand.java
@@ -37,7 +37,7 @@ public class StateExploreCommand extends AbstractStateCommand {
             if (pm.getContainer() != null) {
                 throw new CommandExecutionException("Already entered, use leave command");
             }
-            FeatureContainer container = getFeatureContainer(pm);
+            FeatureContainer container = getFeatureContainer(pm, null);
             pm.setExploredContainer(container);
             prompt = getName() + PathParser.PATH_SEPARATOR;
             pm.setCurrentPath(FeatureContainerPathConsumer.ROOT);

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/state/StateInfoCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/state/StateInfoCommand.java
@@ -17,12 +17,15 @@
 package org.jboss.galleon.cli.cmd.state;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import static org.jboss.galleon.cli.path.FeatureContainerPathConsumer.CONFIGS;
 import static org.jboss.galleon.cli.path.FeatureContainerPathConsumer.DEPENDENCIES;
 
 import java.util.List;
+import java.util.Map;
 import org.aesh.command.CommandDefinition;
 import org.aesh.command.option.Option;
+import org.jboss.galleon.ProvisioningException;
 import org.jboss.galleon.cli.AbstractStateCommand;
 import org.jboss.galleon.cli.CommandExecutionException;
 import org.jboss.galleon.cli.PmCommandInvocation;
@@ -31,6 +34,8 @@ import static org.jboss.galleon.cli.cmd.state.InfoTypeCompleter.ALL;
 import org.jboss.galleon.cli.model.FeatureContainer;
 import org.jboss.galleon.config.FeaturePackConfig;
 import org.jboss.galleon.config.ProvisioningConfig;
+import org.jboss.galleon.layout.ProvisioningLayout;
+import org.jboss.galleon.layout.ProvisioningLayout.FeaturePackLayout;
 import org.jboss.galleon.universe.FeaturePackLocation;
 import org.jboss.galleon.universe.FeaturePackLocation.FPID;
 
@@ -48,31 +53,35 @@ public class StateInfoCommand extends AbstractStateCommand {
     protected void runCommand(PmCommandInvocation invoc) throws CommandExecutionException {
         try {
             ProvisioningConfig config = getProvisioningConfig(invoc.getPmSession());
+            if (!config.hasFeaturePackDeps()) {
+                return;
+            }
             if (type == null) {
                 displayFeaturePacks(invoc, config);
             } else {
-                switch (type) {
-                    case ALL: {
-                        FeatureContainer container = getFeatureContainer(invoc.getPmSession());
-                        displayFeaturePacks(invoc, config);
-                        displayDependencies(invoc, container);
-                        displayConfigs(invoc, container);
-                        break;
-                    }
-                    case CONFIGS: {
-                        FeatureContainer container = getFeatureContainer(invoc.getPmSession());
-                        displayFeaturePacks(invoc, config);
-                        displayConfigs(invoc, container);
-                        break;
-                    }
-                    case DEPENDENCIES: {
-                        FeatureContainer container = getFeatureContainer(invoc.getPmSession());
-                        displayFeaturePacks(invoc, config);
-                        displayDependencies(invoc, container);
-                        break;
-                    }
-                    default: {
-                        throw new CommandExecutionException(CliErrors.invalidInfoType());
+                try (ProvisioningLayout<FeaturePackLayout> layout = invoc.getPmSession().getLayoutFactory().newConfigLayout(config)) {
+                    switch (type) {
+                        case ALL: {
+                            FeatureContainer container = getFeatureContainer(invoc.getPmSession(), layout);
+                            displayFeaturePacks(invoc, config);
+                            displayDependencies(invoc, layout);
+                            displayConfigs(invoc, container);
+                            break;
+                        }
+                        case CONFIGS: {
+                            FeatureContainer container = getFeatureContainer(invoc.getPmSession(), layout);
+                            displayFeaturePacks(invoc, config);
+                            displayConfigs(invoc, container);
+                            break;
+                        }
+                        case DEPENDENCIES: {
+                            displayFeaturePacks(invoc, config);
+                            displayDependencies(invoc, layout);
+                            break;
+                        }
+                        default: {
+                            throw new CommandExecutionException(CliErrors.invalidInfoType());
+                        }
                     }
                 }
             }
@@ -88,42 +97,32 @@ public class StateInfoCommand extends AbstractStateCommand {
         }
     }
 
-    private void displayDependencies(PmCommandInvocation invoc, FeatureContainer container) {
-        List<FeaturePackLocation> locs = new ArrayList<>();
-        ProvisioningConfig config = container.getProvisioningConfig();
-        if (container.getFullDependencies().isEmpty()) {
-            for (FPID id : container.getDependencies()) {
-                if (containsDeps(config, id)) {
-                    continue;
+    private void displayFeaturePacks(PmCommandInvocation invoc, ProvisioningConfig config) {
+        StateInfoUtil.printFeaturePacks(invoc, config.getFeaturePackDeps());
+    }
+
+    private void displayDependencies(PmCommandInvocation invoc, ProvisioningLayout<FeaturePackLayout> layout) throws ProvisioningException {
+        Map<FPID, FeaturePackConfig> configs = new HashMap<>();
+        List<FeaturePackLocation> dependencies = new ArrayList<>();
+        for (FeaturePackLayout fpLayout : layout.getOrderedFeaturePacks()) {
+            boolean isProduct = true;
+            for (FeaturePackLayout fpLayout2 : layout.getOrderedFeaturePacks()) {
+                if (fpLayout2.getSpec().hasTransitiveDep(fpLayout.getFPID().getProducer())
+                        || fpLayout2.getSpec().getFeaturePackDep(fpLayout.getFPID().getProducer()) != null) {
+                    isProduct = false;
+                    break;
                 }
-                locs.add(invoc.getPmSession().
-                        getExposedLocation(id.getLocation()));
             }
-        } else { // A State in memory.
-            for (FeatureContainer c : container.getFullDependencies().values()) {
-                if (containsDeps(config, c.getFPID())) {
-                    continue;
-                }
-                locs.add(invoc.getPmSession().
-                        getExposedLocation(c.getFPID().getLocation()));
+            if (!isProduct) {
+                FeaturePackLocation loc = invoc.getPmSession().getExposedLocation(fpLayout.getFPID().getLocation());
+                dependencies.add(loc);
+                FeaturePackConfig transitiveConfig = layout.getConfig().getTransitiveDep(fpLayout.getFPID().getProducer());
+                configs.put(loc.getFPID(), transitiveConfig);
             }
         }
-        String str = StateInfoUtil.buildDependencies(locs, container.getConfigs());
+        String str = StateInfoUtil.buildDependencies(dependencies, configs);
         if (str != null) {
             invoc.println(str);
         }
-    }
-
-    private static boolean containsDeps(ProvisioningConfig config, FPID id) {
-        for (FeaturePackConfig c : config.getFeaturePackDeps()) {
-            if (c.getLocation().getFPID().equals(id)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private void displayFeaturePacks(PmCommandInvocation invoc, ProvisioningConfig config) {
-        StateInfoUtil.printFeaturePacks(invoc, config.getFeaturePackDeps());
     }
 }

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/state/StateInfoUtil.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/state/StateInfoUtil.java
@@ -360,9 +360,11 @@ public class StateInfoUtil {
             line.add(new Cell(formatChannel(loc)));
             t.addCellsLine(line);
         }
-        commandInvocation.println("");
-        t.sort(Table.SortType.ASCENDANT);
-        commandInvocation.println(t.build());
+        if (!t.isEmpty()) {
+            commandInvocation.println("");
+            t.sort(Table.SortType.ASCENDANT);
+            commandInvocation.println(t.build());
+        }
     }
 
     private static boolean showPatches(Collection<FeaturePackConfig> configs) {

--- a/cli/src/main/java/org/jboss/galleon/cli/model/FeatureContainer.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/model/FeatureContainer.java
@@ -21,8 +21,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import org.jboss.galleon.config.FeaturePackConfig;
 import org.jboss.galleon.config.ProvisioningConfig;
 
 import org.jboss.galleon.runtime.ResolvedSpecId;
@@ -39,7 +37,6 @@ public abstract class FeatureContainer {
     private final Map<String, List<ConfigInfo>> finalConfigs = new HashMap<>();
     private final Map<String, Group> packagesRoots = new HashMap<>();
     private final Map<String, Group> featuresSpecRoots = new HashMap<>();
-    private final Map<FPID, FeaturePackConfig> dependencies = new HashMap<>();
     private Map<String, FeatureContainer> fullDependencies = new HashMap<>();
     private final String name;
     private final FPID fpid;
@@ -57,18 +54,6 @@ public abstract class FeatureContainer {
 
     public ProvisioningConfig getProvisioningConfig() {
         return config;
-    }
-
-    void addDependency(FPID fpid, FeaturePackConfig config) {
-        dependencies.put(fpid, config);
-    }
-
-    public Set<FPID> getDependencies() {
-        return dependencies.keySet();
-    }
-
-    public Map<FPID, FeaturePackConfig> getConfigs() {
-        return Collections.unmodifiableMap(dependencies);
     }
 
     public FPID getFPID() {

--- a/cli/src/main/java/org/jboss/galleon/cli/model/FeatureContainers.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/model/FeatureContainers.java
@@ -80,9 +80,6 @@ public abstract class FeatureContainers {
         Map<String, FeaturePackRuntime> gavs = new HashMap<>();
         for (FeaturePackRuntime rt : runtime.getFeaturePacks()) {
             gavs.put(Identity.buildOrigin(rt.getFPID().getProducer()), rt);
-            // Can be null if no transitive dep declared.
-            FeaturePackConfig config = runtime.getProvisioningConfig().getTransitiveDep(rt.getFPID().getProducer());
-            fp.addDependency(rt.getFPID(), config);
         }
         List<CliPlugin> cliPlugins = new ArrayList<>();
         FeaturePackPluginVisitor<CliPlugin> visitor = new FeaturePackPluginVisitor<CliPlugin>() {


### PR DESCRIPTION
- GAL-96, update completer display transitive deps, ProvisioningLayout to retrieve dependencies.
- Renamed Channel to be Update Channel
- Display nothing for empty install
