### PR TITLE
Fix for GAL-103, re-activate plugin options completion

### DIFF
--- a/cli/src/main/java/org/jboss/galleon/cli/CliMain.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/CliMain.java
@@ -47,12 +47,6 @@ import org.jboss.galleon.cli.cmd.state.feature.FeatureCommand;
  */
 public class CliMain {
 
-    private static final String ENABLE_EXPERIMENTAL_FEATURES = "org.jboss.galleon.cli.enable.experimental.features";
-
-    public static boolean experimentalFeaturesEnabled() {
-        return Boolean.getBoolean(CliMain.ENABLE_EXPERIMENTAL_FEATURES);
-    }
-
     public static void main(String[] args) throws Exception {
         Configuration config = Configuration.parse();
         final PmSession pmSession = new PmSession(config);

--- a/cli/src/main/java/org/jboss/galleon/cli/PmSession.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/PmSession.java
@@ -221,11 +221,13 @@ public class PmSession implements CommandInvocationProvider<PmCommandInvocation>
         return enableTrackers;
     }
 
-    private void registerTrackers() {
-        ProgressTrackers.registerTrackers(this);
+    public void registerTrackers() {
+        if (enableTrackers) {
+            ProgressTrackers.registerTrackers(this);
+        }
     }
 
-    private void unregisterTrackers() {
+    public void unregisterTrackers() {
         ProgressTrackers.unregisterTrackers(this);
     }
 

--- a/cli/src/main/java/org/jboss/galleon/cli/UniverseManager.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/UniverseManager.java
@@ -16,7 +16,6 @@
  */
 package org.jboss.galleon.cli;
 
-import org.jboss.galleon.cli.resolver.PluginResolver;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -123,23 +122,6 @@ public class UniverseManager implements MavenChangeListener {
                             deps.add(ploc);
                         }
                     }
-                    if (CliMain.experimentalFeaturesEnabled()) {
-                        // Then resolve plugins
-                        Future<?> f2 = executorService.submit(() -> {
-                            try {
-                                for (FeaturePackLocation loc : deps) {
-                                    if (closed) {
-                                        return;
-                                    }
-                                    pmSession.getResolver().resolveSync(loc.toString(), PluginResolver.newResolver(pmSession, loc));
-                                }
-                            } catch (Exception ex) {
-                                LOGGER.log(Level.SEVERE, "Can't resolve builtin universe", ex);
-                            }
-                        });
-                        submited.add(f2);
-                    }
-                    LOGGER.log(Level.FINE, "Successfully resolved builtin universe.");
                 } catch (Exception ex) {
                     LOGGER.log(Level.SEVERE, "Can't resolve builtin universe", ex);
                 }

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/plugin/AbstractPluginsCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/plugin/AbstractPluginsCommand.java
@@ -34,7 +34,6 @@ import org.jboss.galleon.cli.CommandExecutionException;
 import org.jboss.galleon.cli.PmCommandInvocation;
 import org.jboss.galleon.cli.PmSession;
 import static org.jboss.galleon.cli.AbstractStateCommand.VERBOSE_OPTION_NAME;
-import org.jboss.galleon.cli.CliMain;
 import org.jboss.galleon.cli.cmd.AbstractDynamicCommand;
 import org.jboss.galleon.cli.cmd.CliErrors;
 import org.jboss.galleon.cli.cmd.FPLocationCompleter;
@@ -50,10 +49,8 @@ import org.jboss.galleon.universe.FeaturePackLocation;
  */
 public abstract class AbstractPluginsCommand extends AbstractDynamicCommand {
 
-    static final String RESOLUTION_MESSAGE = "Resolving options";
-
     public AbstractPluginsCommand(PmSession pmSession) {
-        super(pmSession, true, true, CliMain.experimentalFeaturesEnabled());
+        super(pmSession, true, true);
     }
 
     protected boolean isVerbose() {

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/plugin/AbstractProvisionWithPlugins.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/plugin/AbstractProvisionWithPlugins.java
@@ -16,6 +16,7 @@
  */
 package org.jboss.galleon.cli.cmd.plugin;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -30,7 +31,6 @@ import org.jboss.galleon.ProvisioningException;
 import org.jboss.galleon.ProvisioningManager;
 import static org.jboss.galleon.cli.AbstractStateCommand.DIR_OPTION_NAME;
 import static org.jboss.galleon.cli.AbstractStateCommand.VERBOSE_OPTION_NAME;
-import org.jboss.galleon.cli.CliMain;
 import org.jboss.galleon.cli.CommandExecutionException;
 import org.jboss.galleon.cli.PmCommandActivator;
 import org.jboss.galleon.cli.PmCommandInvocation;
@@ -38,6 +38,7 @@ import org.jboss.galleon.cli.PmSession;
 import org.jboss.galleon.cli.cmd.AbstractDynamicCommand;
 import org.jboss.galleon.cli.cmd.state.NoStateCommandActivator;
 import org.jboss.galleon.cli.cmd.CommandWithInstallationDirectory;
+import org.jboss.galleon.util.PathsUtils;
 
 /**
  *
@@ -46,7 +47,7 @@ import org.jboss.galleon.cli.cmd.CommandWithInstallationDirectory;
 public abstract class AbstractProvisionWithPlugins extends AbstractDynamicCommand implements CommandWithInstallationDirectory {
 
     protected AbstractProvisionWithPlugins(PmSession pmSession) {
-        super(pmSession, true, false, CliMain.experimentalFeaturesEnabled());
+        super(pmSession, true, false);
     }
 
     @Override
@@ -116,5 +117,20 @@ public abstract class AbstractProvisionWithPlugins extends AbstractDynamicComman
     @Override
     protected PmCommandActivator getActivator() {
         return new NoStateCommandActivator();
+    }
+
+    @Override
+    protected boolean canComplete(PmSession pmSession) {
+        //Only if we have a valid directory
+        String targetDirArg = (String) getValue(DIR_OPTION_NAME);
+        if (targetDirArg == null) {
+            // Check in argument or option, that is the option completion case.
+            targetDirArg = getOptionValue(DIR_OPTION_NAME);
+        }
+        if (targetDirArg != null) {
+            return true;
+        }
+        Path workDir = PmSession.getWorkDir(pmSession.getAeshContext());
+        return Files.exists(PathsUtils.getProvisioningXml(workDir));
     }
 }

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/plugin/StateProvisionCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/plugin/StateProvisionCommand.java
@@ -39,7 +39,6 @@ import org.jboss.galleon.cli.PmCommandInvocation;
 import org.jboss.galleon.cli.PmOptionActivator;
 import org.jboss.galleon.cli.PmSession;
 import org.jboss.galleon.cli.cmd.CliErrors;
-import static org.jboss.galleon.cli.cmd.plugin.AbstractPluginsCommand.RESOLUTION_MESSAGE;
 import org.jboss.galleon.cli.cmd.state.StateNoExplorationActivator;
 import org.jboss.galleon.cli.model.state.State;
 import org.jboss.galleon.cli.resolver.PluginResolver;
@@ -92,14 +91,21 @@ public class StateProvisionCommand extends AbstractProvisionWithPlugins {
                 return Collections.emptyList();
             }
             ProvisioningConfig config = ProvisioningXmlParser.parse(getAbsolutePath(file, pmSession.getAeshContext()));
-            opts = pmSession.getResolver().get(id, PluginResolver.newResolver(pmSession, config),
-                    RESOLUTION_MESSAGE).getInstall();
+            opts = pmSession.getResolver().get(id, PluginResolver.newResolver(pmSession, config)).getInstall();
         }
         for (PluginOption opt : opts) {
             DynamicOption dynOption = new DynamicOption(opt.getName(), opt.isRequired(), opt.isAcceptsValue());
             options.add(dynOption);
         }
         return options;
+    }
+
+    @Override
+    protected boolean canComplete(PmSession pmSession) {
+        if (pmSession.getState() != null) {
+            return true;
+        }
+        return super.canComplete(pmSession);
     }
 
     private Set<PluginOption> getPluginOptions(ProvisioningRuntime runtime) throws ProvisioningException {

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/state/InfoTypeCompleter.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/state/InfoTypeCompleter.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import org.jboss.galleon.cli.AbstractCompleter;
 import org.jboss.galleon.cli.PmCompleterInvocation;
+import static org.jboss.galleon.cli.path.FeatureContainerPathConsumer.OPTIONS;
 
 /**
  *
@@ -36,7 +37,7 @@ public class InfoTypeCompleter extends AbstractCompleter {
 
     @Override
     protected List<String> getItems(PmCompleterInvocation completerInvocation) {
-        return Arrays.asList(ALL, CONFIGS, DEPENDENCIES, PATCHES);
+        return Arrays.asList(ALL, CONFIGS, DEPENDENCIES, OPTIONS, PATCHES);
     }
 
 }

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/state/StateInfoCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/state/StateInfoCommand.java
@@ -33,6 +33,8 @@ import org.jboss.galleon.cli.cmd.CliErrors;
 import static org.jboss.galleon.cli.cmd.state.InfoTypeCompleter.ALL;
 import static org.jboss.galleon.cli.cmd.state.InfoTypeCompleter.PATCHES;
 import org.jboss.galleon.cli.model.FeatureContainer;
+import static org.jboss.galleon.cli.path.FeatureContainerPathConsumer.OPTIONS;
+import org.jboss.galleon.cli.resolver.PluginResolver;
 import org.jboss.galleon.config.FeaturePackConfig;
 import org.jboss.galleon.config.ProvisioningConfig;
 import org.jboss.galleon.layout.ProvisioningLayout;
@@ -68,6 +70,7 @@ public class StateInfoCommand extends AbstractStateCommand {
                             displayDependencies(invoc, layout);
                             displayPatches(invoc, layout);
                             displayConfigs(invoc, container);
+                            displayOptions(invoc, layout);
                             break;
                         }
                         case CONFIGS: {
@@ -84,6 +87,14 @@ public class StateInfoCommand extends AbstractStateCommand {
                             if (deps != null) {
                                 displayFeaturePacks(invoc, config);
                                 invoc.println(deps);
+                            }
+                            break;
+                        }
+                        case OPTIONS: {
+                            String options = buildOptions(layout);
+                            if (options != null) {
+                                displayFeaturePacks(invoc, config);
+                                invoc.println(options);
                             }
                             break;
                         }
@@ -160,5 +171,17 @@ public class StateInfoCommand extends AbstractStateCommand {
 
     private String buildPatches(PmCommandInvocation invoc, ProvisioningLayout<FeaturePackLayout> layout) throws ProvisioningException {
         return StateInfoUtil.buildPatches(invoc, layout);
+    }
+
+    private String buildOptions(ProvisioningLayout<FeaturePackLayout> layout) throws ProvisioningException {
+        return StateInfoUtil.buildOptions(PluginResolver.resolvePlugins(layout));
+    }
+
+    private void displayOptions(PmCommandInvocation commandInvocation,
+            ProvisioningLayout layout) throws ProvisioningException {
+        String str = buildOptions(layout);
+        if (str != null) {
+            commandInvocation.println(str);
+        }
     }
 }

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/state/feature/StateAddFeatureCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/state/feature/StateAddFeatureCommand.java
@@ -120,7 +120,12 @@ public class StateAddFeatureCommand extends AbstractDynamicCommand {
     }
 
     public StateAddFeatureCommand(PmSession pmSession) {
-        super(pmSession, false, true, true);
+        super(pmSession, false, true);
+    }
+
+    @Override
+    protected boolean canComplete(PmSession pmSession) {
+        return true;
     }
 
     @Override

--- a/cli/src/main/java/org/jboss/galleon/cli/resolver/ResourceResolver.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/resolver/ResourceResolver.java
@@ -100,7 +100,7 @@ public class ResourceResolver {
     }
 
     @SuppressWarnings("unchecked")
-    public <T> T get(String key, Resolver<T> res, String msg) throws InterruptedException, ExecutionException {
+    public <T> T get(String key, Resolver<T> res) throws InterruptedException, ExecutionException {
         CompletableFuture<T> comp;
         synchronized (this) {
             comp = (CompletableFuture<T>) content.get(key);

--- a/docs/guide/tool/state.adoc
+++ b/docs/guide/tool/state.adoc
@@ -70,15 +70,23 @@ _feature-pack info wildfly:current#1.0.0-Alpha1_
 _install <[FPL|FPID] | [--file=<path to fp zip file>]> [--dir=<installation dir>] [--verbose] [feature-pack specific options]_
 
 This creates a directory containing the installed feature-pack content (binaries, configs). +
-NB: To retrieve the set of feature-pack specific options call: +
+
+NB: Using completion, when an installation directory has been identified, the options that
+are specific to the feature-pack to install are proposed. When installing for the first time
+a feature-pack this can take some time (a matter of few seconds up to minutes 
+if the feature-pack needs to be downloaded from a remote location).
+
+You can retrieve the set of feature-pack specific options without relying on completion, to do so call: +
 _feature-pack info <[FPL|FPID] | [--file=<path to fp zip file>]> --type=options_ +
-You can then use the listed options (if any) to customize your installation.
+You can then use the listed options (if any) to customize your install command.
 
 ### Un-installing a feature-pack
 
 _uninstall [FPID] [--dir=<installation dir>]_
 
 This will remove the content installed by the feature-pack identified by the FPID.
+
+NB: Completer proposes the FPID you can un-install from the installation (products and patches).
 
 ### Un-doing the last provisioning command
 
@@ -90,7 +98,7 @@ This will revert the installation to the previous installed state.
 
 Use the _install_ command to patch an existing installation.
 
-_install [--file=<path to patch fp zip file>]> [--dir=<installation dir>] [--verbose] [feature-pack specific options]_
+_install <[FPL|FPID] | [--file=<path to patch zip file>]> [--dir=<installation dir>] [--verbose] [feature-pack specific options]_
 
 ### Un-installing a patch
 
@@ -104,10 +112,19 @@ If no directory is provided, the current directory is used. If no products are p
 
 ### Updating an installation
 
-_state update [--dir=<installation dir> [--include-all-dependencies] [--yes] [--products=<list of products>] [list of discovered feature-pack options]_
+_state update [--dir=<installation dir>] [--include-all-dependencies] [--yes] [--products=<list of products>] [feature-pack specific options]_
 
 Display the list of available updates/patches then update. If no directory is provided, the current directory is used. 
 If _--yes_ is provided, the command will proceed without asking for confirmation.
+
+NB: Using completion, when an installation directory has been identified, the options that
+are specific to the installed feature-pack(s) are proposed. When updating an installation for the first time 
+this can take some time (a matter of few seconds up to minutes if the feature-pack 
+needs to be downloaded from a remote location).
+
+You can retrieve the set of feature-pack specific options without relying on completion, to do so call: +
+_state info [--dir=<installation dir>] --type=options_ +
+You can then use the listed options (if any) to customize your update command.
 
 ### Observing an installation
 
@@ -129,7 +146,12 @@ _[my-dir]$ state export <new generated xml file> --dir=<installation>_
 
 ###  Provisioning an installation from xml
 
-_[my-dir]$ state provision <xml file> --dir=<target installation directory>_
+_[my-dir]$ state provision <xml file> --dir=<target installation directory> [feature-pack specific options]_
+
+NB: Using completion, when an installation directory has been identified, the options that
+are specific to the feature-pack(s) located in the XML configuration file are proposed. 
+When provisioning an installation for the first time this can take some time 
+(a matter of few seconds up to minutes if the feature-pack needs to be downloaded from a remote location).
 
 ### Managing the history of an installation
 


### PR DESCRIPTION
- Removed experimental sys property
- Background resolution does only resolve producers and channels, no plugins.
- Plugin options are completed when appropriate. Still some latency but that is the current "state of the art", latency is acceptable.
- Options can be displayed when getting info for an installation.
- Documented the possible latency (possible because options could have been retrieved by previous provisioning commands).
