### PR TITLE
Fix for GAL-121, snapshot never, release daily. Make policies configurable

### DIFF
--- a/cli/src/main/java/org/jboss/galleon/cli/Util.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/Util.java
@@ -28,7 +28,6 @@ import org.eclipse.aether.connector.basic.BasicRepositoryConnectorFactory;
 import org.eclipse.aether.impl.DefaultServiceLocator;
 import org.eclipse.aether.repository.LocalRepository;
 import org.eclipse.aether.repository.ProxySelector;
-import static org.eclipse.aether.repository.RepositoryPolicy.UPDATE_POLICY_DAILY;
 import org.eclipse.aether.spi.connector.RepositoryConnectorFactory;
 import org.eclipse.aether.spi.connector.transport.TransporterFactory;
 import org.eclipse.aether.transport.file.FileTransporterFactory;
@@ -57,7 +56,6 @@ public class Util {
         session.setOffline(offline);
         final LocalRepository localRepo = new LocalRepository(path.toString());
         session.setLocalRepositoryManager(repoSystem.newLocalRepositoryManager(session, localRepo));
-        session.setUpdatePolicy(UPDATE_POLICY_DAILY);
         if (proxySelector != null) {
             session.setProxySelector(proxySelector);
         }

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/CliErrors.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/CliErrors.java
@@ -86,6 +86,10 @@ public interface CliErrors {
         return "Invalid info type";
     }
 
+    static String invalidMavenUpdatePolicy(String policy) {
+        return "Invalid update policy " + policy;
+    }
+
     static String invalidUniverse() {
         return "Invalid universe";
     }

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/mvn/MavenCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/mvn/MavenCommand.java
@@ -28,7 +28,7 @@ import org.jboss.galleon.cli.PmCommandInvocation;
  */
 @GroupCommandDefinition(description = "", name = "mvn", groupCommands = {MavenAddRepository.class,
     MavenRemoveRepository.class, MavenInfo.class, MavenSetLocalRepository.class, FetchArtifact.class,
-    MavenSetSettings.class})
+    MavenSetSettings.class, MavenSetReleasePolicy.class, MavenSetSnapshotPolicy.class})
 public class MavenCommand implements Command<PmCommandInvocation> {
 
     @Override

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/mvn/MavenInfo.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/mvn/MavenInfo.java
@@ -40,6 +40,8 @@ public class MavenInfo extends PmSessionCommand {
         t.addLine("Maven xml settings", (config.getSettings() == null ? "No settings file set"
                 : config.getSettings().normalize().toString()));
         t.addLine("Local repository", config.getLocalRepository().normalize().toString());
+        t.addLine("Default release policy", config.getDefaultReleasePolicy());
+        t.addLine("Default snapshot policy", config.getDefaultSnapshotPolicy());
         Cell repositories = new Cell();
         Cell title = new Cell("Remote repositories");
         if (config.getRemoteRepositories().isEmpty()) {
@@ -50,6 +52,10 @@ public class MavenInfo extends PmSessionCommand {
                 repositories.addLine(rep.getName());
                 repositories.addLine(" url=" + rep.getUrl());
                 repositories.addLine(" type=" + rep.getType());
+                repositories.addLine(" releaseUpdatePolicy=" + (rep.getReleaseUpdatePolicy() == null
+                        ? config.getDefaultReleasePolicy() : rep.getReleaseUpdatePolicy()));
+                repositories.addLine(" snapshotUpdatePolicy=" + (rep.getSnapshotUpdatePolicy() == null
+                        ? config.getDefaultSnapshotPolicy() : rep.getSnapshotUpdatePolicy()));
             }
         }
         t.addCellsLine(title, repositories);

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/mvn/MavenSetReleasePolicy.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/mvn/MavenSetReleasePolicy.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.galleon.cli.cmd.mvn;
+
+import java.io.IOException;
+import javax.xml.stream.XMLStreamException;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.option.Argument;
+import org.jboss.galleon.ProvisioningException;
+import org.jboss.galleon.cli.CommandExecutionException;
+import org.jboss.galleon.cli.PmCommandInvocation;
+import org.jboss.galleon.cli.PmSessionCommand;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+@CommandDefinition(name = "set-release-update-policy", description = "Set the default release update policy")
+public class MavenSetReleasePolicy extends PmSessionCommand {
+
+    @Argument(completer = MavenAddRepository.UpdatePolicyCompleter.class)
+    private String policy;
+
+    @Override
+    protected void runCommand(PmCommandInvocation session) throws CommandExecutionException {
+        try {
+            session.getPmSession().getPmConfiguration().getMavenConfig().setDefaultReleasePolicy(policy);
+        } catch (ProvisioningException | XMLStreamException | IOException ex) {
+            throw new CommandExecutionException(ex.getLocalizedMessage());
+        }
+    }
+
+}

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/mvn/MavenSetSnapshotPolicy.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/mvn/MavenSetSnapshotPolicy.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.galleon.cli.cmd.mvn;
+
+import java.io.IOException;
+import javax.xml.stream.XMLStreamException;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.option.Argument;
+import org.jboss.galleon.ProvisioningException;
+import org.jboss.galleon.cli.CommandExecutionException;
+import org.jboss.galleon.cli.PmCommandInvocation;
+import org.jboss.galleon.cli.PmSessionCommand;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+@CommandDefinition(name = "set-snapshot-update-policy", description = "Set the default snapshot update policy")
+public class MavenSetSnapshotPolicy extends PmSessionCommand {
+
+    @Argument(completer = MavenAddRepository.UpdatePolicyCompleter.class)
+    private String policy;
+
+    @Override
+    protected void runCommand(PmCommandInvocation session) throws CommandExecutionException {
+        try {
+            session.getPmSession().getPmConfiguration().getMavenConfig().setDefaultSnapshotPolicy(policy);
+        } catch (ProvisioningException | XMLStreamException | IOException ex) {
+            throw new CommandExecutionException(ex.getLocalizedMessage());
+        }
+    }
+
+}

--- a/cli/src/main/java/org/jboss/galleon/cli/config/mvn/MavenCliSettings.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/config/mvn/MavenCliSettings.java
@@ -23,6 +23,8 @@ import org.eclipse.aether.RepositoryListener;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.repository.RepositoryPolicy;
+import static org.eclipse.aether.repository.RepositoryPolicy.CHECKSUM_POLICY_WARN;
 import org.jboss.galleon.cli.Util;
 
 /**
@@ -54,10 +56,14 @@ class MavenCliSettings implements MavenSettings {
     private List<RemoteRepository> buildRepositories(MavenConfig config) throws ArtifactException {
         List<RemoteRepository> repos = new ArrayList<>();
         for (MavenRemoteRepository repo : config.getRemoteRepositories()) {
-            // The default policy for both snapshots and releases is to update daily.
-            // This is required in order for the CLI to check in the remote repository for new releases.
             RemoteRepository.Builder builder = new RemoteRepository.Builder(repo.getName(),
                     repo.getType(), repo.getUrl());
+            builder.setSnapshotPolicy(new RepositoryPolicy(true,
+                    repo.getSnapshotUpdatePolicy() == null ? config.getDefaultSnapshotPolicy() : repo.getSnapshotUpdatePolicy(),
+                    CHECKSUM_POLICY_WARN));
+            builder.setReleasePolicy(new RepositoryPolicy(true,
+                    repo.getReleaseUpdatePolicy() == null ? config.getDefaultReleasePolicy() : repo.getReleaseUpdatePolicy(),
+                    CHECKSUM_POLICY_WARN));
             repos.add(builder.build());
         }
         return repos;

--- a/cli/src/main/java/org/jboss/galleon/cli/config/mvn/MavenConfigXml.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/config/mvn/MavenConfigXml.java
@@ -34,6 +34,8 @@ public class MavenConfigXml {
     public static final String LOCAL_REPOSITORY = "local-repository";
     public static final String SETTINGS = "settings";
     public static final String NAME = "name";
+    public static final String SNAPSHOT_UPDATE_POLICY = "snapshotUpdatePolicy";
+    public static final String RELEASE_UPDATE_POLICY = "releaseUpdatePolicy";
     public static final String TYPE = "type";
     public static final String REPOSITORY = "repository";
     public static final String MAVEN = "maven";
@@ -58,6 +60,14 @@ public class MavenConfigXml {
                         }
                         case SETTINGS: {
                             config.setSettings(Paths.get(reader.getElementText()));
+                            break;
+                        }
+                        case SNAPSHOT_UPDATE_POLICY: {
+                            config.setDefaultSnapshotPolicy(reader.getElementText());
+                            break;
+                        }
+                        case RELEASE_UPDATE_POLICY: {
+                            config.setDefaultReleasePolicy(reader.getElementText());
                             break;
                         }
                         default: {
@@ -87,7 +97,8 @@ public class MavenConfigXml {
                     switch (reader.getLocalName()) {
                         case REPOSITORY: {
                             MavenRemoteRepository repo = new MavenRemoteRepository(reader.getAttributeValue(null, NAME),
-                                    reader.getAttributeValue(null, TYPE), reader.getElementText());
+                                    reader.getAttributeValue(null, TYPE), reader.getAttributeValue(null, RELEASE_UPDATE_POLICY),
+                                    reader.getAttributeValue(null, SNAPSHOT_UPDATE_POLICY), reader.getElementText());
                             config.addRemoteRepository(repo);
                             break;
                         }

--- a/cli/src/main/java/org/jboss/galleon/cli/config/mvn/MavenRemoteRepository.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/config/mvn/MavenRemoteRepository.java
@@ -16,6 +16,8 @@
  */
 package org.jboss.galleon.cli.config.mvn;
 
+import org.jboss.galleon.ProvisioningException;
+
 /**
  *
  * @author jdenise@redhat.com
@@ -24,11 +26,27 @@ public class MavenRemoteRepository {
     private final String name;
     private final String url;
     private final String type;
+    private final String releaseUpdatePolicy;
+    private final String snapshotUpdatePolicy;
 
-    public MavenRemoteRepository(String name, String type, String url) {
+    MavenRemoteRepository(String name, String type, String url) {
         this.name = name;
         this.url = url;
         this.type = type;
+        // Will be set with default configured policies.
+        this.releaseUpdatePolicy = null;
+        this.snapshotUpdatePolicy = null;
+    }
+
+    public MavenRemoteRepository(String name, String type, String releaseUpdatePolicy,
+            String snapshotUpdatePolicy, String url) throws ProvisioningException {
+        this.name = name;
+        this.url = url;
+        this.type = type;
+        MavenConfig.validatePolicy(releaseUpdatePolicy);
+        this.releaseUpdatePolicy = releaseUpdatePolicy;
+        MavenConfig.validatePolicy(snapshotUpdatePolicy);
+        this.snapshotUpdatePolicy = snapshotUpdatePolicy;
     }
 
     /**
@@ -50,6 +68,20 @@ public class MavenRemoteRepository {
      */
     public String getType() {
         return type;
+    }
+
+    /**
+     * @return the updateReleasePolicy
+     */
+    public String getReleaseUpdatePolicy() {
+        return releaseUpdatePolicy;
+    }
+
+    /**
+     * @return the updateSnapshotPolicy
+     */
+    public String getSnapshotUpdatePolicy() {
+        return snapshotUpdatePolicy;
     }
 
 }

--- a/docs/guide/tool/maven.adoc
+++ b/docs/guide/tool/maven.adoc
@@ -16,12 +16,20 @@ NB: Any other cli maven configuration items will be overridden when a settings x
 NB: If no local repository is set in settings file, the local repository (default or configured) is used.
 
 ### Adding new remote repositories
-Type the following commands: +
-_mvn add-repository --name=myrepo --url=http://foorepo_ +
+Use the following command to add new remote repositories: +
+_mvn add-repository --name=myrepo --url=http://foorepo [--release-update-policy=<policy>] [--snapshot-update-policy=<policy>] [--type=<type>]_ +
 
-### Repository policies (this could be made configurable)
-Daily update. +
+NB: The type, release update policy and snapshot update policy are optional and have default values.
+
+### Default Repository policies
+Daily update for releases, never update for snapshots. +
 Warn if checksum differs.
+
+Update polices can be changed by calling: +
+_mvn set-release-update-policy <always|daily|interval:|never>_ +
+_mvn set-snapshot-update-policy <always|daily|interval:|never>_
+
+NB: Calling one of these commands without any argument will reset to the default value.
 
 ### Advanced maven configuration
 Proxy, authentication, mirroring and offline are only supported when setting a maven xml settings file.

--- a/testsuite/src/test/java/org/jboss/galleon/cli/CliWrapper.java
+++ b/testsuite/src/test/java/org/jboss/galleon/cli/CliWrapper.java
@@ -47,14 +47,14 @@ public class CliWrapper {
         userHome = System.getProperty("user.home");
         testUserHome = Files.createTempDir();
         System.setProperty("user.home", testUserHome.getAbsolutePath());
-        mvnRepo = new File(testUserHome, "mvn");
+        // This is the default repository if no repository has been set.
+        mvnRepo = new File(testUserHome, ".m2" + File.separator + "repository");
         mvnRepo.mkdir();
         session = new PmSession(Configuration.parse());
         runtime = CliMain.newRuntime(session, new PrintStream(out));
         session.getUniverse().disableBackgroundResolution();
         session.throwException();
         session.enableTrackers(false);
-        session.getPmConfiguration().getMavenConfig().setLocalRepository(mvnRepo.toPath());
     }
 
     public String getOutput() {

--- a/testsuite/src/test/java/org/jboss/galleon/cli/MavenConfigTestCase.java
+++ b/testsuite/src/test/java/org/jboss/galleon/cli/MavenConfigTestCase.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.galleon.cli;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.aesh.command.CommandException;
+import org.jboss.galleon.cli.config.Configuration;
+import org.jboss.galleon.cli.config.mvn.MavenConfig;
+import org.jboss.galleon.cli.config.mvn.MavenRemoteRepository;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+public class MavenConfigTestCase {
+
+    private static CliWrapper cli;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        cli = new CliWrapper();
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        cli.close();
+    }
+
+    @Test
+    public void testRepository() throws Exception {
+        MavenConfig config = cli.getSession().getPmConfiguration().getMavenConfig();
+        String name = "foofoo";
+        String name2 = "barbar";
+        String url = "http://foo";
+        try {
+            cli.execute("mvn add-repository --name=" + name + " --url=" + url + " --release-update-policy=foo");
+            throw new Exception("Should have failed");
+        } catch (CommandException ex) {
+            // XXX OK
+        }
+
+        try {
+            cli.execute("mvn add-repository --name=" + name + " --url=" + url + " --snapshot-update-policy=foo");
+            throw new Exception("Should have failed");
+        } catch (CommandException ex) {
+            // XXX OK
+        }
+        cli.execute("mvn add-repository --name=" + name + " --url=" + url);
+        cli.execute("mvn add-repository --name=" + name2 + " --url=" + url + " --snapshot-update-policy=always --release-update-policy=never");
+        checkRepositories(config, url, name, name2);
+        checkRepositories(Configuration.parse().getMavenConfig(), url, name, name2);
+
+        try {
+            cli.execute("mvn remove-repository XXX");
+            throw new Exception("Should have failed");
+        } catch (CommandException ex) {
+            // XXX OK
+        }
+        cli.execute("mvn info");
+        Assert.assertTrue(cli.getOutput().contains(name));
+        Assert.assertTrue(cli.getOutput().contains(name2));
+
+        cli.execute("mvn remove-repository " + name);
+        cli.execute("mvn remove-repository " + name2);
+        checkNoRepositories(config, name, name2);
+        checkNoRepositories(Configuration.parse().getMavenConfig(), name, name2);
+    }
+
+    @Test
+    public void testLocalRepository() throws Exception {
+        MavenConfig config = cli.getSession().getPmConfiguration().getMavenConfig();
+        Path defaultOriginalPath = config.getLocalRepository();
+        Path foo = cli.newDir("foo", true);
+        Assert.assertFalse(config.getLocalRepository().endsWith("foo"));
+        cli.execute("mvn set-local-repository " + foo.toFile().getAbsolutePath());
+        Assert.assertEquals(foo, config.getLocalRepository());
+        Assert.assertEquals(foo, Configuration.parse().getMavenConfig().getLocalRepository());
+
+        cli.execute("mvn info");
+        Assert.assertTrue(cli.getOutput().contains(foo.toFile().getAbsolutePath()));
+
+        cli.execute("mvn set-local-repository");
+        Assert.assertEquals(defaultOriginalPath, config.getLocalRepository());
+        Assert.assertEquals(defaultOriginalPath, Configuration.parse().getMavenConfig().getLocalRepository());
+    }
+
+    @Test
+    public void testSettingsFile() throws Exception {
+        MavenConfig config = cli.getSession().getPmConfiguration().getMavenConfig();
+        Path p = cli.newDir("foo", true);
+        Path settings = p.resolve("settings.xml");
+        Files.createFile(settings);
+        Path existingSettings = config.getSettings();
+        Assert.assertNull(existingSettings);
+        cli.execute("mvn set-settings-file " + settings.toFile().getAbsolutePath());
+        Assert.assertEquals(settings, config.getSettings());
+        Assert.assertEquals(settings, Configuration.parse().getMavenConfig().getSettings());
+
+        cli.execute("mvn info");
+        Assert.assertTrue(cli.getOutput().contains(settings.toFile().getAbsolutePath()));
+
+        cli.execute("mvn set-settings-file");
+        Assert.assertNull(config.getSettings());
+        Assert.assertNull(Configuration.parse().getMavenConfig().getSettings());
+    }
+
+    @Test
+    public void testUpdatePolicies() throws Exception {
+        MavenConfig config = cli.getSession().getPmConfiguration().getMavenConfig();
+        String defaultRelease = config.getDefaultReleasePolicy();
+        String defaultSnapshot = config.getDefaultSnapshotPolicy();
+        String snapshotPolicy = "interval:700";
+        String releasePolicy = "never";
+        try {
+            cli.execute("mvn set-release-update-policy interval:");
+            throw new Exception("Should have failed");
+        } catch (CommandException ex) {
+            // XXX OK
+        }
+
+        try {
+            cli.execute("mvn set-snapshot-update-policy interval:");
+            throw new Exception("Should have failed");
+        } catch (CommandException ex) {
+            // XXX OK
+        }
+
+        cli.execute("mvn set-snapshot-update-policy " + snapshotPolicy);
+        cli.execute("mvn set-release-update-policy " + releasePolicy);
+
+        cli.execute("mvn info");
+        Assert.assertTrue(cli.getOutput().contains("snapshotUpdatePolicy=" + snapshotPolicy));
+        Assert.assertTrue(cli.getOutput().contains("releaseUpdatePolicy=" + releasePolicy));
+
+        Assert.assertEquals(snapshotPolicy, config.getDefaultSnapshotPolicy());
+        Assert.assertEquals(releasePolicy, config.getDefaultReleasePolicy());
+
+        Assert.assertEquals(snapshotPolicy, Configuration.parse().getMavenConfig().getDefaultSnapshotPolicy());
+        Assert.assertEquals(releasePolicy, Configuration.parse().getMavenConfig().getDefaultReleasePolicy());
+
+        cli.execute("mvn set-snapshot-update-policy");
+        cli.execute("mvn set-release-update-policy");
+
+        Assert.assertEquals(defaultSnapshot, config.getDefaultSnapshotPolicy());
+        Assert.assertEquals(defaultRelease, config.getDefaultReleasePolicy());
+
+        Assert.assertEquals(defaultSnapshot, Configuration.parse().getMavenConfig().getDefaultSnapshotPolicy());
+        Assert.assertEquals(defaultRelease, Configuration.parse().getMavenConfig().getDefaultReleasePolicy());
+    }
+
+
+    private static void checkNoRepositories(MavenConfig config, String... names) throws Exception {
+        for (String s : names) {
+            Assert.assertFalse(config.getRemoteRepositoryNames().contains(s));
+        }
+    }
+
+    private static void checkRepositories(MavenConfig config, String url, String name, String name2) throws Exception {
+        MavenRemoteRepository repo = getRepository(config, name);
+        Assert.assertNotNull(repo);
+        Assert.assertNull(repo.getReleaseUpdatePolicy());
+        Assert.assertNull(repo.getSnapshotUpdatePolicy());
+        Assert.assertEquals("default", repo.getType());
+        Assert.assertEquals(url, repo.getUrl());
+
+        repo = getRepository(config, name2);
+        Assert.assertNotNull(repo);
+        Assert.assertEquals("always", repo.getSnapshotUpdatePolicy());
+        Assert.assertEquals("never", repo.getReleaseUpdatePolicy());
+        Assert.assertEquals(url, repo.getUrl());
+
+    }
+
+    private static MavenRemoteRepository getRepository(MavenConfig config, String name) {
+        for (MavenRemoteRepository repo : config.getRemoteRepositories()) {
+            if (repo.getName().equals(name)) {
+                return repo;
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
- Never for snapshots, Daily for releases.
- Can update/reset and persist default policies. Completer to help set right policy.
- New policy update options when adding remote repository
- mvn commands testing.