### PR TITLE
Fix for GAL-122, CLI maven release vs snapshot activation

### DIFF
--- a/cli/src/main/java/org/jboss/galleon/cli/PmSession.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/PmSession.java
@@ -113,34 +113,44 @@ public class PmSession implements CommandInvocationProvider<PmCommandInvocation>
 
         @Override
         public void artifactResolving(RepositoryEvent re) {
-            //session.println("artifactResolving " + re);
+//            if (active && re != null) {
+//                println("artifactResolving " + re);
+//            }
         }
 
         @Override
         public void artifactResolved(RepositoryEvent re) {
-            //session.println("artifactResolved " + re);
+//            if (active && re != null) {
+//                println("artifactResolved " + re);
+//            }
         }
 
         @Override
         public void metadataResolving(RepositoryEvent re) {
-            //session.println("metadataResolving " + re);
-
+//            if (active && re != null) {
+//                println("metadataResolving " + re);
+//            }
         }
 
         @Override
         public void metadataResolved(RepositoryEvent re) {
-            //session.println("metadataResolved " + re);
-
+//            if (active && re != null) {
+//                println("metadataResolved " + re);
+//            }
         }
 
         @Override
         public void metadataDownloading(RepositoryEvent re) {
-            //session.println("metadataDownloading " + re);
+//            if (active && re != null) {
+//                println("metadataDownloading " + re);
+//            }
         }
 
         @Override
         public void metadataDownloaded(RepositoryEvent re) {
-            //session.println("metadataDownloaded " + re);
+//            if (active && re != null) {
+//                println("metadataDownloaded " + re);
+//            }
         }
 
         @Override

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/BooleanCompleter.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/BooleanCompleter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.galleon.cli.cmd;
+
+import java.util.Arrays;
+import java.util.List;
+import org.jboss.galleon.cli.AbstractCompleter;
+import org.jboss.galleon.cli.CommandExecutionException;
+import org.jboss.galleon.cli.PmCompleterInvocation;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+public class BooleanCompleter extends AbstractCompleter {
+
+    private static final List<String> VALUES = Arrays.asList("false", "true");
+
+    @Override
+    protected List<String> getItems(PmCompleterInvocation completerInvocation) {
+        return VALUES;
+    }
+
+    public static Boolean validateValue(String value) throws CommandExecutionException {
+        if (value != null) {
+            if (!VALUES.contains(value)) {
+                throw new CommandExecutionException(CliErrors.invalidBoolean(value));
+            }
+            return Boolean.parseBoolean(value);
+        } else {
+            return null;
+        }
+    }
+}

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/CliErrors.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/CliErrors.java
@@ -78,6 +78,10 @@ public interface CliErrors {
         return failed("Get history limit");
     }
 
+    static String invalidBoolean(String value) {
+        return "Invalid boolean value " + value;
+    }
+
     static String invalidHistoryLimit(String limit) {
         return "Invalid history limit " + limit;
     }

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/mvn/MavenAddRepository.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/mvn/MavenAddRepository.java
@@ -65,12 +65,18 @@ public class MavenAddRepository extends PmSessionCommand {
             description = "Maven snapshot update policy. NB: Interval is expressed in minutes", required = false)
     private String snapshotUpdatePolicy;
 
+    @Option(hasValue = true, name = "enable-snapshot", description = "Enable snapshot")
+    private Boolean enableSnapshot;
+
+    @Option(hasValue = true, name = "enable-release", description = "Enable release")
+    private Boolean enableRelease;
+
     @Override
     protected void runCommand(PmCommandInvocation session) throws CommandExecutionException {
         try {
             session.getPmSession().getPmConfiguration().getMavenConfig().
                     addRemoteRepository(new MavenRemoteRepository(name, type,
-                            releaseUpdatePolicy, snapshotUpdatePolicy, url));
+                            releaseUpdatePolicy, snapshotUpdatePolicy, enableRelease, enableSnapshot, url));
         } catch (ProvisioningException | XMLStreamException | IOException ex) {
             throw new CommandExecutionException(session.getPmSession(), CliErrors.addRepositoryFailed(), ex);
         }

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/mvn/MavenCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/mvn/MavenCommand.java
@@ -28,7 +28,8 @@ import org.jboss.galleon.cli.PmCommandInvocation;
  */
 @GroupCommandDefinition(description = "", name = "mvn", groupCommands = {MavenAddRepository.class,
     MavenRemoveRepository.class, MavenInfo.class, MavenSetLocalRepository.class, FetchArtifact.class,
-    MavenSetSettings.class, MavenSetReleasePolicy.class, MavenSetSnapshotPolicy.class})
+    MavenSetSettings.class, MavenSetReleasePolicy.class, MavenSetSnapshotPolicy.class,
+    MavenEnableRelease.class, MavenEnableSnapshot.class})
 public class MavenCommand implements Command<PmCommandInvocation> {
 
     @Override

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/mvn/MavenEnableRelease.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/mvn/MavenEnableRelease.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.galleon.cli.cmd.mvn;
+
+import java.io.IOException;
+import javax.xml.stream.XMLStreamException;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.option.Argument;
+import org.jboss.galleon.cli.CommandExecutionException;
+import org.jboss.galleon.cli.PmCommandInvocation;
+import org.jboss.galleon.cli.PmSessionCommand;
+import org.jboss.galleon.cli.cmd.BooleanCompleter;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+
+
+@CommandDefinition(name = "enable-release", description = "Enable release by default")
+public class MavenEnableRelease extends PmSessionCommand {
+    @Argument(completer = BooleanCompleter.class)
+    private String enable;
+
+    @Override
+    protected void runCommand(PmCommandInvocation session) throws CommandExecutionException {
+        try {
+            session.getPmSession().getPmConfiguration().getMavenConfig().
+                    enableRelease(BooleanCompleter.validateValue(enable));
+        } catch (XMLStreamException | IOException ex) {
+            throw new CommandExecutionException(ex.getLocalizedMessage());
+        }
+    }
+
+}

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/mvn/MavenEnableSnapshot.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/mvn/MavenEnableSnapshot.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.galleon.cli.cmd.mvn;
+
+import java.io.IOException;
+import javax.xml.stream.XMLStreamException;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.option.Argument;
+import org.jboss.galleon.cli.CommandExecutionException;
+import org.jboss.galleon.cli.PmCommandInvocation;
+import org.jboss.galleon.cli.PmSessionCommand;
+import org.jboss.galleon.cli.cmd.BooleanCompleter;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+
+
+@CommandDefinition(name = "enable-snapshot", description = "Enable snapshot by default")
+public class MavenEnableSnapshot extends PmSessionCommand {
+
+    @Argument(completer = BooleanCompleter.class)
+    private String enable;
+
+    @Override
+    protected void runCommand(PmCommandInvocation session) throws CommandExecutionException {
+        try {
+            session.getPmSession().getPmConfiguration().getMavenConfig().
+                    enableSnapshot(BooleanCompleter.validateValue(enable));
+        } catch (XMLStreamException | IOException ex) {
+            throw new CommandExecutionException(ex.getLocalizedMessage());
+        }
+    }
+
+}

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/mvn/MavenInfo.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/mvn/MavenInfo.java
@@ -42,6 +42,8 @@ public class MavenInfo extends PmSessionCommand {
         t.addLine("Local repository", config.getLocalRepository().normalize().toString());
         t.addLine("Default release policy", config.getDefaultReleasePolicy());
         t.addLine("Default snapshot policy", config.getDefaultSnapshotPolicy());
+        t.addLine("Enable release", "" + config.isReleaseEnabled());
+        t.addLine("Enable snapshot", "" + config.isSnapshotEnabled());
         Cell repositories = new Cell();
         Cell title = new Cell("Remote repositories");
         if (config.getRemoteRepositories().isEmpty()) {
@@ -52,8 +54,10 @@ public class MavenInfo extends PmSessionCommand {
                 repositories.addLine(rep.getName());
                 repositories.addLine(" url=" + rep.getUrl());
                 repositories.addLine(" type=" + rep.getType());
+                repositories.addLine(" release=" + (rep.getEnableRelease() == null ? config.isReleaseEnabled() : rep.getEnableRelease()));
                 repositories.addLine(" releaseUpdatePolicy=" + (rep.getReleaseUpdatePolicy() == null
                         ? config.getDefaultReleasePolicy() : rep.getReleaseUpdatePolicy()));
+                repositories.addLine(" snapshot=" + (rep.getEnableSnapshot() == null ? config.isSnapshotEnabled() : rep.getEnableSnapshot()));
                 repositories.addLine(" snapshotUpdatePolicy=" + (rep.getSnapshotUpdatePolicy() == null
                         ? config.getDefaultSnapshotPolicy() : rep.getSnapshotUpdatePolicy()));
             }

--- a/cli/src/main/java/org/jboss/galleon/cli/config/mvn/MavenCliSettings.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/config/mvn/MavenCliSettings.java
@@ -58,10 +58,10 @@ class MavenCliSettings implements MavenSettings {
         for (MavenRemoteRepository repo : config.getRemoteRepositories()) {
             RemoteRepository.Builder builder = new RemoteRepository.Builder(repo.getName(),
                     repo.getType(), repo.getUrl());
-            builder.setSnapshotPolicy(new RepositoryPolicy(true,
+            builder.setSnapshotPolicy(new RepositoryPolicy(repo.getEnableSnapshot() == null ? config.isSnapshotEnabled() : repo.getEnableSnapshot(),
                     repo.getSnapshotUpdatePolicy() == null ? config.getDefaultSnapshotPolicy() : repo.getSnapshotUpdatePolicy(),
                     CHECKSUM_POLICY_WARN));
-            builder.setReleasePolicy(new RepositoryPolicy(true,
+            builder.setReleasePolicy(new RepositoryPolicy(repo.getEnableRelease() == null ? config.isReleaseEnabled() : repo.getEnableRelease(),
                     repo.getReleaseUpdatePolicy() == null ? config.getDefaultReleasePolicy() : repo.getReleaseUpdatePolicy(),
                     CHECKSUM_POLICY_WARN));
             repos.add(builder.build());

--- a/cli/src/main/java/org/jboss/galleon/cli/config/mvn/MavenConfig.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/config/mvn/MavenConfig.java
@@ -49,6 +49,9 @@ public class MavenConfig {
     static final String DEFAULT_SNAPSHOT_UPDATE_POLICY = UPDATE_POLICY_NEVER;
     static final String DEFAULT_RELEASE_UPDATE_POLICY = UPDATE_POLICY_DAILY;
 
+    static final boolean DEFAULT_ENABLE_SNAPSHOT = false;
+    static final boolean DEFAULT_ENABLE_RELEASE = true;
+
     private static final List<String> VALID_UPDATE_POLICIES;
 
     static {
@@ -77,6 +80,35 @@ public class MavenConfig {
     private Path settings;
     private String defaultSnapshotPolicy = DEFAULT_SNAPSHOT_UPDATE_POLICY;
     private String defaultReleasePolicy = DEFAULT_RELEASE_UPDATE_POLICY;
+
+    private boolean defaultEnableSnapshot = DEFAULT_ENABLE_SNAPSHOT;
+    private boolean defaultEnableRelease = DEFAULT_ENABLE_RELEASE;
+
+    public boolean isSnapshotEnabled() {
+        return defaultEnableSnapshot;
+    }
+
+    public boolean isReleaseEnabled() {
+        return defaultEnableRelease;
+    }
+
+    public void enableSnapshot(Boolean enable) throws XMLStreamException, IOException {
+        if (enable == null) {
+            defaultEnableSnapshot = DEFAULT_ENABLE_SNAPSHOT;
+        } else {
+            defaultEnableSnapshot = enable;
+        }
+        advertise();
+    }
+
+    public void enableRelease(Boolean enable) throws XMLStreamException, IOException {
+        if (enable == null) {
+            defaultEnableRelease = DEFAULT_ENABLE_RELEASE;
+        } else {
+            defaultEnableRelease = enable;
+        }
+        advertise();
+    }
 
     public String getDefaultSnapshotPolicy() {
         return defaultSnapshotPolicy;
@@ -178,6 +210,16 @@ public class MavenConfig {
             writer.writeCharacters(defaultSnapshotPolicy);
             writer.writeEndElement();
         }
+        if (defaultEnableSnapshot != DEFAULT_ENABLE_SNAPSHOT) {
+            writer.writeStartElement(MavenConfigXml.ENABLE_SNAPSHOT);
+            writer.writeCharacters(Boolean.toString(defaultEnableSnapshot));
+            writer.writeEndElement();
+        }
+        if (defaultEnableRelease != DEFAULT_ENABLE_RELEASE) {
+            writer.writeStartElement(MavenConfigXml.ENABLE_RELEASE);
+            writer.writeCharacters(Boolean.toString(defaultEnableRelease));
+            writer.writeEndElement();
+        }
         if (settings != null) {
             writer.writeStartElement(MavenConfigXml.SETTINGS);
             writer.writeCharacters(settings.toAbsolutePath().toString());
@@ -197,6 +239,12 @@ public class MavenConfig {
                 }
                 if (repo.getSnapshotUpdatePolicy() != null) {
                     writer.writeAttribute(MavenConfigXml.SNAPSHOT_UPDATE_POLICY, repo.getSnapshotUpdatePolicy());
+                }
+                if (repo.getEnableRelease() != null) {
+                    writer.writeAttribute(MavenConfigXml.ENABLE_RELEASE, Boolean.toString(repo.getEnableRelease()));
+                }
+                if (repo.getEnableSnapshot() != null) {
+                    writer.writeAttribute(MavenConfigXml.ENABLE_SNAPSHOT, Boolean.toString(repo.getEnableSnapshot()));
                 }
                 writer.writeCharacters(repo.getUrl());
                 writer.writeEndElement();

--- a/cli/src/main/java/org/jboss/galleon/cli/config/mvn/MavenConfigXml.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/config/mvn/MavenConfigXml.java
@@ -36,6 +36,8 @@ public class MavenConfigXml {
     public static final String NAME = "name";
     public static final String SNAPSHOT_UPDATE_POLICY = "snapshotUpdatePolicy";
     public static final String RELEASE_UPDATE_POLICY = "releaseUpdatePolicy";
+    public static final String ENABLE_SNAPSHOT = "enableSnapshot";
+    public static final String ENABLE_RELEASE = "enableRelease";
     public static final String TYPE = "type";
     public static final String REPOSITORY = "repository";
     public static final String MAVEN = "maven";
@@ -70,6 +72,14 @@ public class MavenConfigXml {
                             config.setDefaultReleasePolicy(reader.getElementText());
                             break;
                         }
+                        case ENABLE_SNAPSHOT: {
+                            config.enableSnapshot(Boolean.parseBoolean(reader.getElementText()));
+                            break;
+                        }
+                        case ENABLE_RELEASE: {
+                            config.enableRelease(Boolean.parseBoolean(reader.getElementText()));
+                            break;
+                        }
                         default: {
                             throw ParsingUtils.unexpectedContent(reader);
                         }
@@ -96,9 +106,14 @@ public class MavenConfigXml {
                 case XMLStreamConstants.START_ELEMENT: {
                     switch (reader.getLocalName()) {
                         case REPOSITORY: {
+                            String snapshot = reader.getAttributeValue(null, ENABLE_SNAPSHOT);
+                            String release = reader.getAttributeValue(null, ENABLE_RELEASE);
                             MavenRemoteRepository repo = new MavenRemoteRepository(reader.getAttributeValue(null, NAME),
                                     reader.getAttributeValue(null, TYPE), reader.getAttributeValue(null, RELEASE_UPDATE_POLICY),
-                                    reader.getAttributeValue(null, SNAPSHOT_UPDATE_POLICY), reader.getElementText());
+                                    reader.getAttributeValue(null, SNAPSHOT_UPDATE_POLICY),
+                                    release == null ? null : Boolean.parseBoolean(release),
+                                    snapshot == null ? null : Boolean.parseBoolean(snapshot),
+                                    reader.getElementText());
                             config.addRemoteRepository(repo);
                             break;
                         }

--- a/cli/src/main/java/org/jboss/galleon/cli/config/mvn/MavenRemoteRepository.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/config/mvn/MavenRemoteRepository.java
@@ -28,7 +28,8 @@ public class MavenRemoteRepository {
     private final String type;
     private final String releaseUpdatePolicy;
     private final String snapshotUpdatePolicy;
-
+    private final Boolean enableSnapshot;
+    private final Boolean enableRelease;
     MavenRemoteRepository(String name, String type, String url) {
         this.name = name;
         this.url = url;
@@ -36,10 +37,13 @@ public class MavenRemoteRepository {
         // Will be set with default configured policies.
         this.releaseUpdatePolicy = null;
         this.snapshotUpdatePolicy = null;
+        this.enableRelease = null;
+        this.enableSnapshot = null;
     }
 
     public MavenRemoteRepository(String name, String type, String releaseUpdatePolicy,
-            String snapshotUpdatePolicy, String url) throws ProvisioningException {
+            String snapshotUpdatePolicy, Boolean enableRelease,
+            Boolean enableSnapshot, String url) throws ProvisioningException {
         this.name = name;
         this.url = url;
         this.type = type;
@@ -47,6 +51,8 @@ public class MavenRemoteRepository {
         this.releaseUpdatePolicy = releaseUpdatePolicy;
         MavenConfig.validatePolicy(snapshotUpdatePolicy);
         this.snapshotUpdatePolicy = snapshotUpdatePolicy;
+        this.enableRelease = enableRelease;
+        this.enableSnapshot = enableSnapshot;
     }
 
     /**
@@ -82,6 +88,20 @@ public class MavenRemoteRepository {
      */
     public String getSnapshotUpdatePolicy() {
         return snapshotUpdatePolicy;
+    }
+
+    /**
+     * @return the enableSnapshot
+     */
+    public Boolean getEnableSnapshot() {
+        return enableSnapshot;
+    }
+
+    /**
+     * @return the enableRelease
+     */
+    public Boolean getEnableRelease() {
+        return enableRelease;
     }
 
 }

--- a/docs/guide/tool/maven.adoc
+++ b/docs/guide/tool/maven.adoc
@@ -17,17 +17,25 @@ NB: If no local repository is set in settings file, the local repository (defaul
 
 ### Adding new remote repositories
 Use the following command to add new remote repositories: +
-_mvn add-repository --name=myrepo --url=http://foorepo [--release-update-policy=<policy>] [--snapshot-update-policy=<policy>] [--type=<type>]_ +
+_mvn add-repository --name=myrepo --url=http://foorepo [--release-update-policy=<policy>] 
+[--snapshot-update-policy=<policy>] [--type=<type>] [--enable-release=[true|false] [--enable-snapshot=[true|false]_ +
 
-NB: The type, release update policy and snapshot update policy are optional and have default values.
+NB: The type, release update policy, snapshot update policy and enable/disable of snapshot/release are optional and have default values.
 
 ### Default Repository policies
 Daily update for releases, never update for snapshots. +
 Warn if checksum differs.
 
+Snapshots are not resolved from remote repositories. + 
+Releases are resolved from remote repositories.
+
 Update polices can be changed by calling: +
-_mvn set-release-update-policy <always|daily|interval:|never>_ +
-_mvn set-snapshot-update-policy <always|daily|interval:|never>_
+_mvn set-release-update-policy [<always|daily|interval:|never>]_ +
+_mvn set-snapshot-update-policy [<always|daily|interval:|never>]_
+
+Activation of snapshot/release resolution can be changed by calling: +
+_mvn enable-snapshot [<true|false>]_ +
+_mvn enable-release [<true|false>]_
 
 NB: Calling one of these commands without any argument will reset to the default value.
 


### PR DESCRIPTION
- Snapshot not resolved from remote repo by default.
- Configuration items to enable/disable activation globally and per repo.
- New tests.
