### PR TITLE
Fix for GAL-118, layout cache controlled by CLI

### DIFF
--- a/cli/src/main/java/org/jboss/galleon/cli/CliMain.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/CliMain.java
@@ -51,6 +51,7 @@ public class CliMain {
     public static void main(String[] args) throws Exception {
         Configuration config = Configuration.parse();
         final PmSession pmSession = new PmSession(config);
+        pmSession.cleanupLayoutCache();
         // Side effect is to resolve plugins.
         pmSession.getUniverse().resolveBuiltinUniverse();
 

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/CliErrors.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/CliErrors.java
@@ -16,6 +16,8 @@
  */
 package org.jboss.galleon.cli.cmd;
 
+import java.nio.file.Path;
+
 /**
  *
  * @author jdenise@redhat.com
@@ -80,6 +82,10 @@ public interface CliErrors {
 
     static String invalidBoolean(String value) {
         return "Invalid boolean value " + value;
+    }
+
+    static String invalidConfigDirectory(Path galleonDir) {
+        return "Configuration directory " + galleonDir + " is not a directory.";
     }
 
     static String invalidHistoryLimit(String limit) {

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/featurepack/ClearCacheCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/featurepack/ClearCacheCommand.java
@@ -16,24 +16,26 @@
  */
 package org.jboss.galleon.cli.cmd.featurepack;
 
-import org.aesh.command.Command;
-import org.aesh.command.CommandException;
-import org.aesh.command.CommandResult;
-import org.aesh.command.GroupCommandDefinition;
-import org.aesh.command.invocation.CommandInvocation;
+import java.io.IOException;
+import org.aesh.command.CommandDefinition;
+import org.jboss.galleon.cli.CommandExecutionException;
+import org.jboss.galleon.cli.PmCommandInvocation;
+import org.jboss.galleon.cli.PmSessionCommand;
 
 /**
  *
  * @author jdenise@redhat.com
  */
-@GroupCommandDefinition(description = "", name = "feature-pack", groupCommands = {ImportCommand.class,
-    InfoCommand.class, ExploreCommand.class, ClearCacheCommand.class})
-public class FeaturePackCommand implements Command<CommandInvocation> {
+@CommandDefinition(name = "clear-cache", description = "Clear the cache of feature-packs.")
+public class ClearCacheCommand extends PmSessionCommand {
 
     @Override
-    public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
-        commandInvocation.println("subcommand missing");
-        return CommandResult.FAILURE;
+    protected void runCommand(PmCommandInvocation session) throws CommandExecutionException {
+        try {
+            session.getPmSession().clearLayoutCache();
+        } catch (IOException ex) {
+            throw new CommandExecutionException(ex.getMessage());
+        }
     }
 
 }

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/plugin/AbstractPluginsCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/plugin/AbstractPluginsCommand.java
@@ -50,7 +50,7 @@ import org.jboss.galleon.universe.FeaturePackLocation;
 public abstract class AbstractPluginsCommand extends AbstractDynamicCommand {
 
     public AbstractPluginsCommand(PmSession pmSession) {
-        super(pmSession, true, true);
+        super(pmSession, true);
     }
 
     protected boolean isVerbose() {
@@ -116,9 +116,9 @@ public abstract class AbstractPluginsCommand extends AbstractDynamicCommand {
     }
 
     @Override
-    protected List<DynamicOption> getDynamicOptions(State state, String id) throws Exception {
+    protected List<DynamicOption> getDynamicOptions(State state) throws Exception {
         List<DynamicOption> options = new ArrayList<>();
-        FeaturePackLocation fpl = pmSession.getResolvedLocation(id);
+        FeaturePackLocation fpl = pmSession.getResolvedLocation(getId(pmSession));
         Set<PluginOption> pluginOptions = getPluginOptions(fpl);
         for (PluginOption opt : pluginOptions) {
             DynamicOption dynOption = new DynamicOption(opt.getName(), opt.isRequired(), opt.isAcceptsValue());
@@ -135,7 +135,6 @@ public abstract class AbstractPluginsCommand extends AbstractDynamicCommand {
         return session.getPmSession().newProvisioningManager(getInstallationHome(session.getAeshContext()), isVerbose());
     }
 
-    @Override
     protected String getId(PmSession session) throws CommandExecutionException {
         String streamName = (String) getValue(ARGUMENT_NAME);
         if (streamName == null) {

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/plugin/AbstractProvisionWithPlugins.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/plugin/AbstractProvisionWithPlugins.java
@@ -47,13 +47,7 @@ import org.jboss.galleon.util.PathsUtils;
 public abstract class AbstractProvisionWithPlugins extends AbstractDynamicCommand implements CommandWithInstallationDirectory {
 
     protected AbstractProvisionWithPlugins(PmSession pmSession) {
-        super(pmSession, true, false);
-    }
-
-    @Override
-    protected String getId(PmSession session) throws CommandExecutionException {
-        // We can't cache anything.
-        return null;
+        super(pmSession, true);
     }
 
     protected abstract List<ProcessedOption> getOtherOptions() throws OptionParserException;

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/plugin/StateProvisionCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/plugin/StateProvisionCommand.java
@@ -78,7 +78,7 @@ public class StateProvisionCommand extends AbstractProvisionWithPlugins {
     }
 
     @Override
-    protected List<DynamicOption> getDynamicOptions(State state, String id) throws Exception {
+    protected List<DynamicOption> getDynamicOptions(State state) throws Exception {
         List<DynamicOption> options = new ArrayList<>();
         ProvisioningRuntime rt;
         Set<PluginOption> opts;
@@ -91,7 +91,7 @@ public class StateProvisionCommand extends AbstractProvisionWithPlugins {
                 return Collections.emptyList();
             }
             ProvisioningConfig config = ProvisioningXmlParser.parse(getAbsolutePath(file, pmSession.getAeshContext()));
-            opts = pmSession.getResolver().get(id, PluginResolver.newResolver(pmSession, config)).getInstall();
+            opts = pmSession.getResolver().get(null, PluginResolver.newResolver(pmSession, config)).getInstall();
         }
         for (PluginOption opt : opts) {
             DynamicOption dynOption = new DynamicOption(opt.getName(), opt.isRequired(), opt.isAcceptsValue());

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/plugin/UninstallCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/plugin/UninstallCommand.java
@@ -106,7 +106,7 @@ public class UninstallCommand extends AbstractProvisionWithPlugins {
     }
 
     @Override
-    protected List<DynamicOption> getDynamicOptions(State state, String id) throws Exception {
+    protected List<DynamicOption> getDynamicOptions(State state) throws Exception {
         String fpid = getFPID();
         Path dir = getAbsolutePath(getUninstallDir(), pmSession.getAeshContext());
         // Build layout from this directory.

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/state/StateUpdateCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/state/StateUpdateCommand.java
@@ -100,7 +100,7 @@ public class StateUpdateCommand extends AbstractProvisionWithPlugins {
     }
 
     @Override
-    protected List<DynamicOption> getDynamicOptions(State state, String id) throws Exception {
+    protected List<DynamicOption> getDynamicOptions(State state) throws Exception {
         String targetDirArg = (String) getValue(DIR_OPTION_NAME);
         if (targetDirArg == null) {
             // Check in argument or option, that is the option completion case.
@@ -109,7 +109,7 @@ public class StateUpdateCommand extends AbstractProvisionWithPlugins {
         Path workDir = PmSession.getWorkDir(pmSession.getAeshContext());
         Path installation = targetDirArg == null ? workDir : workDir.resolve(targetDirArg);
         ProvisioningConfig config = pmSession.newProvisioningManager(installation, false).getProvisioningConfig();
-        Set<PluginOption> opts = pmSession.getResolver().get(id, PluginResolver.newResolver(pmSession, config)).getDiff();
+        Set<PluginOption> opts = pmSession.getResolver().get(null, PluginResolver.newResolver(pmSession, config)).getDiff();
         List<DynamicOption> options = new ArrayList<>();
         for (PluginOption opt : opts) {
             DynamicOption dynOption = new DynamicOption(opt.getName(), opt.isRequired(), opt.isAcceptsValue());

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/state/feature/StateAddFeatureCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/state/feature/StateAddFeatureCommand.java
@@ -120,7 +120,7 @@ public class StateAddFeatureCommand extends AbstractDynamicCommand {
     }
 
     public StateAddFeatureCommand(PmSession pmSession) {
-        super(pmSession, false, true);
+        super(pmSession, false);
     }
 
     @Override
@@ -133,7 +133,7 @@ public class StateAddFeatureCommand extends AbstractDynamicCommand {
         try {
             session.getPmSession().getState().addFeature(session.getPmSession(),
                     getSpec(session.getPmSession().getState(),
-                            getId(session.getPmSession())), getConfiguration(session.getPmSession().getState()), options);
+                            getId()), getConfiguration(session.getPmSession().getState()), options);
         } catch (IOException | PathParserException | PathConsumerException | ProvisioningException ex) {
             throw new CommandExecutionException(session.getPmSession(), CliErrors.addFeatureFailed(), ex);
         }
@@ -176,8 +176,7 @@ public class StateAddFeatureCommand extends AbstractDynamicCommand {
         return "Add a new feature";
     }
 
-    @Override
-    protected String getId(PmSession session) {
+    private String getId() {
         List<String> args = (List<String>) getValue(ARGUMENT_NAME);
         if (args == null) {
             // Check in argument, that is the option completion case.
@@ -206,9 +205,9 @@ public class StateAddFeatureCommand extends AbstractDynamicCommand {
     }
 
     @Override
-    protected List<DynamicOption> getDynamicOptions(State state, String id) throws Exception {
+    protected List<DynamicOption> getDynamicOptions(State state) throws Exception {
         List<DynamicOption> options = new ArrayList<>();
-        for (Entry<String, FeatureParameterSpec> entry : getSpec(state, id).getSpec().getParams().entrySet()) {
+        for (Entry<String, FeatureParameterSpec> entry : getSpec(state, getId()).getSpec().getParams().entrySet()) {
             DynamicOption dyn = new DynamicOption(entry.getKey(), !entry.getValue().isNillable() && !entry.getValue().hasDefaultValue(), true);
             String defValue = entry.getValue().getDefaultValue();
             if (defValue != null) {

--- a/core/src/main/java/org/jboss/galleon/cache/FeaturePackCacheManager.java
+++ b/core/src/main/java/org/jboss/galleon/cache/FeaturePackCacheManager.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.galleon.cache;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.jboss.galleon.Errors;
+import org.jboss.galleon.ProvisioningException;
+import org.jboss.galleon.universe.FeaturePackLocation;
+import org.jboss.galleon.universe.FeaturePackLocation.FPID;
+import org.jboss.galleon.universe.UniverseResolver;
+import org.jboss.galleon.util.IoUtils;
+import org.jboss.galleon.util.LayoutUtils;
+import org.jboss.galleon.util.ZipUtils;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+public class FeaturePackCacheManager implements Closeable {
+
+    public interface OverwritePolicy {
+
+        boolean hasExpired(Path fpDir, FPID fpid);
+
+        void cached(FPID fpid);
+    }
+
+    private static class DefaultOverwritePolicy implements OverwritePolicy {
+
+        @Override
+        public boolean hasExpired(Path fpDir, FPID fpid) {
+            return false;
+        }
+
+        @Override
+        public void cached(FPID fpid) {
+        }
+    }
+
+    private final Path home;
+    private final OverwritePolicy overwritePolicy;
+
+    public FeaturePackCacheManager() {
+        this(null, null);
+    }
+
+    public FeaturePackCacheManager(Path home) {
+        this(home, null);
+    }
+
+    public FeaturePackCacheManager(Path home, OverwritePolicy overwritePolicy) {
+        this.home = home == null ? IoUtils.createRandomTmpDir() : home;
+        this.overwritePolicy = overwritePolicy == null ? new DefaultOverwritePolicy() : overwritePolicy;
+    }
+
+    public Path put(UniverseResolver universeResolver, FeaturePackLocation fpl) throws ProvisioningException {
+        Path fpDir = LayoutUtils.getFeaturePackDir(home, fpl.getFPID(), false);
+        if (Files.exists(fpDir)) {
+            if (!overwritePolicy.hasExpired(fpDir, fpl.getFPID())) {
+                return fpDir;
+            }
+            IoUtils.recursiveDelete(fpDir);
+        }
+        unpack(fpDir, universeResolver.resolve(fpl));
+        overwritePolicy.cached(fpl.getFPID());
+        return fpDir;
+    }
+
+    public Path put(Path featurePack, FeaturePackLocation.FPID fpid) throws ProvisioningException {
+        final Path fpDir = LayoutUtils.getFeaturePackDir(home, fpid, false);
+        if (Files.exists(fpDir)) {
+            IoUtils.recursiveDelete(fpDir);
+        }
+
+        unpack(fpDir, featurePack);
+        overwritePolicy.cached(fpid);
+        return fpDir;
+    }
+
+    public void remove(FeaturePackLocation.FPID fpid) throws ProvisioningException {
+        IoUtils.recursiveDelete(LayoutUtils.getFeaturePackDir(home, fpid, false));
+    }
+
+    @Override
+    public void close() {
+        IoUtils.recursiveDelete(home);
+    }
+
+    public Path getHome() {
+        return home;
+    }
+
+    private void unpack(final Path fpDir, final Path artifactPath) throws ProvisioningException {
+        try {
+            Files.createDirectories(fpDir);
+        } catch (IOException e) {
+            throw new ProvisioningException(Errors.mkdirs(fpDir), e);
+        }
+        try {
+            ZipUtils.unzip(artifactPath, fpDir);
+        } catch (IOException e) {
+            throw new ProvisioningException("Failed to unzip " + artifactPath + " to " + fpDir, e);
+        }
+    }
+}

--- a/core/src/main/java/org/jboss/galleon/universe/Channel.java
+++ b/core/src/main/java/org/jboss/galleon/universe/Channel.java
@@ -53,4 +53,6 @@ public interface Channel {
         }
         return updateRequest.buildPlan();
     }
+
+    boolean isDevBuild(FPID fpid);
 }

--- a/core/src/main/java/org/jboss/galleon/universe/galleon1/LegacyGalleon1Channel.java
+++ b/core/src/main/java/org/jboss/galleon/universe/galleon1/LegacyGalleon1Channel.java
@@ -65,6 +65,11 @@ public class LegacyGalleon1Channel implements Channel {
 
     @Override
     public String getLatestBuild(FeaturePackLocation.FPID fpid) throws ProvisioningException {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public boolean isDevBuild(FeaturePackLocation.FPID fpid) {
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 }

--- a/docs/guide/tool/state.adoc
+++ b/docs/guide/tool/state.adoc
@@ -142,6 +142,21 @@ _[my-dir]$ feature-pack info <[FPL|FPID] | [--file=<path to fp zip file>]> --typ
 Display the FPID of a feature-pack. In addition can display dependencies, configurations 
 and options usable when installing/provisioning/upgrading.
 
+### Managing the local cache of feature-packs
+
+When a feature-pack is internally resolved (at install time, to expose information, 
+to retrieve plugin options, ...). The feature-pack is added to a local cache. 
+This cache is re-used to speed-up future resolutions. The CLI cleanup un-used feature-pack from the cache
+that are older than one month. 
+
+You can import (and optionally install in the universe for later resolution) a feature-pack zip file in the cache.
+
+_[my-dir]$ feature-pack import <path to fp zip file> [--install-in-universe=<true|false>]_
+
+You can clear the cache fully (NB: this will have a performance impact for future resolution).
+
+_[my-dir]$ feature-pack clear-cache_
+
 ### Exporting an installation to xml
 
 _[my-dir]$ state export <new generated xml file> --dir=<installation>_

--- a/maven-universe/src/main/java/org/jboss/galleon/universe/maven/MavenChannel.java
+++ b/maven-universe/src/main/java/org/jboss/galleon/universe/maven/MavenChannel.java
@@ -26,6 +26,7 @@ import org.jboss.galleon.universe.Channel;
 import org.jboss.galleon.universe.FeaturePackLocation;
 import org.jboss.galleon.universe.LatestVersionNotAvailableException;
 import org.jboss.galleon.universe.Producer;
+import org.jboss.galleon.universe.maven.repo.MavenArtifactVersion;
 import org.jboss.galleon.util.StringUtils;
 
 /**
@@ -252,5 +253,11 @@ public class MavenChannel implements Channel, MavenChannelDescription {
         } catch (MavenUniverseException e) {
             throw e;
         }
+    }
+
+    @Override
+    public boolean isDevBuild(FeaturePackLocation.FPID fpid) {
+        MavenArtifactVersion version = new MavenArtifactVersion(fpid.getBuild());
+        return version.isSnapshot();
     }
 }

--- a/testsuite/src/test/java/org/jboss/galleon/cache/FeaturePackCacheManagerTestCase.java
+++ b/testsuite/src/test/java/org/jboss/galleon/cache/FeaturePackCacheManagerTestCase.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.galleon.cache;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+import org.jboss.galleon.cache.FeaturePackCacheManager.OverwritePolicy;
+import org.jboss.galleon.creator.FeaturePackCreator;
+import org.jboss.galleon.repo.RepositoryArtifactResolver;
+import org.jboss.galleon.universe.FeaturePackLocation;
+import org.jboss.galleon.universe.MvnUniverse;
+import org.jboss.galleon.universe.TestConstants;
+import org.jboss.galleon.universe.UniverseResolver;
+import org.jboss.galleon.universe.UniverseSpec;
+import org.jboss.galleon.universe.maven.MavenUniverseFactory;
+import org.jboss.galleon.universe.maven.repo.MavenRepoManager;
+import org.jboss.galleon.universe.maven.repo.SimplisticMavenRepoManager;
+import org.jboss.galleon.util.IoUtils;
+import org.junit.AfterClass;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+public class FeaturePackCacheManagerTestCase {
+
+    private static class OverwritePolicyTest implements OverwritePolicy {
+
+        Set<FeaturePackLocation.FPID> seen = new HashSet<>();
+        boolean expired;
+        @Override
+        public boolean hasExpired(Path fpDir, FeaturePackLocation.FPID fpid) {
+            return expired;
+        }
+
+        @Override
+        public void cached(FeaturePackLocation.FPID fpid) {
+            seen.add(fpid);
+        }
+
+    }
+
+    private static final String UNIVERSE_NAME = "test-universe";
+    private static FeaturePackLocation.FPID FPID;
+    private static UniverseResolver universeResolver;
+    private static Path installDir;
+    private static Path repoHome;
+    private static Path fpFile;
+
+    @BeforeClass
+    public static void startup() throws Exception {
+        installDir = IoUtils.createRandomTmpDir();
+        repoHome = IoUtils.createRandomTmpDir();
+        RepositoryArtifactResolver repo = SimplisticMavenRepoManager.getInstance(repoHome);
+        universeResolver = UniverseResolver.builder().addArtifactResolver((MavenRepoManager) repo).build();
+        MvnUniverse universe = MvnUniverse.getInstance(UNIVERSE_NAME, (MavenRepoManager) repo);
+        universe.createProducer("prod1");
+        universe.install();
+        FPID = new FeaturePackLocation(new UniverseSpec(MavenUniverseFactory.ID,
+                TestConstants.GROUP_ID + ":" + UNIVERSE_NAME), "prod1", "1", null, "1.0.0").getFPID();
+        FeaturePackCreator creator = FeaturePackCreator.getInstance().addArtifactResolver((MavenRepoManager) repo);
+        creator.newFeaturePack(FPID)
+                .newPackage("p1", true)
+                .writeContent("fp1/p1.txt", "fp1 p1");
+        creator.install();
+        creator.install(installDir);
+        fpFile = installDir.toFile().listFiles()[0].toPath();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        try {
+            IoUtils.recursiveDelete(installDir);
+        } finally {
+            IoUtils.recursiveDelete(repoHome);
+        }
+    }
+
+    @Test
+    public void testPut() throws Exception {
+        try (FeaturePackCacheManager mgr = new FeaturePackCacheManager()) {
+            Path fp = mgr.put(universeResolver, FPID.getLocation());
+            assertTrue(Files.exists(fp));
+
+            mgr.remove(FPID);
+            assertFalse(Files.exists(fp));
+        }
+    }
+
+    @Test
+    public void testOverwrite() throws Exception {
+        Path home = IoUtils.createRandomTmpDir();
+        Path fp = null;
+        OverwritePolicyTest policy = new OverwritePolicyTest();
+        try (FeaturePackCacheManager mgr = new FeaturePackCacheManager(home, policy)) {
+            assertEquals(home, mgr.getHome());
+
+            fp = mgr.put(universeResolver, FPID.getLocation());
+            assertTrue(policy.seen.contains(FPID));
+
+            policy.seen.clear();
+            mgr.put(universeResolver, FPID.getLocation());
+            assertFalse(policy.seen.contains(FPID));
+
+            policy.expired = true;
+            policy.seen.clear();
+            mgr.put(universeResolver, FPID.getLocation());
+            assertTrue(policy.seen.contains(FPID));
+        } finally {
+            assertFalse(Files.exists(home));
+            if (fp != null) {
+                assertFalse(Files.exists(fp));
+            }
+        }
+    }
+
+    @Test
+    public void testFile() throws Exception {
+        assertTrue(Files.exists(fpFile));
+        OverwritePolicyTest policy = new OverwritePolicyTest();
+        try (FeaturePackCacheManager mgr = new FeaturePackCacheManager(null, policy)) {
+            Path fp = mgr.put(fpFile, FPID);
+            assertTrue(Files.exists(fp));
+            assertTrue(policy.seen.contains(FPID));
+            policy.seen.clear();
+            mgr.put(fpFile, FPID);
+            assertTrue(policy.seen.contains(FPID));
+        }
+    }
+}

--- a/testsuite/src/test/java/org/jboss/galleon/cli/CliTestCase.java
+++ b/testsuite/src/test/java/org/jboss/galleon/cli/CliTestCase.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.galleon.cli;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import static org.jboss.galleon.cli.CliTestUtils.PRODUCER1;
+import static org.jboss.galleon.cli.CliTestUtils.PRODUCER2;
+import static org.jboss.galleon.cli.CliTestUtils.UNIVERSE_NAME;
+import org.jboss.galleon.universe.FeaturePackLocation;
+import org.jboss.galleon.universe.MvnUniverse;
+import org.jboss.galleon.universe.UniverseSpec;
+import org.jboss.galleon.util.LayoutUtils;
+import org.junit.AfterClass;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+public class CliTestCase {
+    private static UniverseSpec universeSpec;
+    private static CliWrapper cli;
+    private static MvnUniverse universe;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        cli = new CliWrapper();
+        universe = MvnUniverse.getInstance(UNIVERSE_NAME, cli.getSession().getMavenRepoManager());
+        universeSpec = CliTestUtils.setupUniverse(universe, cli, UNIVERSE_NAME, Arrays.asList(PRODUCER1, PRODUCER2));
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        cli.close();
+    }
+
+    @Test
+    public void testCache() throws Exception {
+        CliTestUtils.install(cli, universeSpec, PRODUCER1, "1.0.0.Alpha1");
+        CliTestUtils.install(cli, universeSpec, PRODUCER1, "1.0.0.Alpha1-SNAPSHOT");
+        Path cache = cli.getSession().getPmConfiguration().getLayoutCache();
+        assertFalse(Files.exists(cache));
+
+        Path p = cli.newDir("install", false);
+        FeaturePackLocation fpl = CliTestUtils.buildFPL(universeSpec, PRODUCER1, "1", "alpha", "1.0.0.Alpha1");
+        cli.execute("install " + fpl + " --dir=" + p);
+        assertTrue(Files.exists(cache));
+        assertTrue(cache.toFile().list().length == 1);
+        assertTrue(Files.exists(LayoutUtils.getFeaturePackDir(cache, fpl.getFPID(), true)));
+        String lastUsage = cli.getSession().getPmConfiguration().getLayoutCacheContent().getProperty(fpl.getFPID().toString());
+        assertNotNull(lastUsage);
+        assertTrue(cli.getSession().getPmConfiguration().getLayoutCacheContent().size() == 1);
+
+        cli.execute("install " + fpl
+                + " --dir=" + p);
+        assertTrue(Files.exists(cache));
+        assertTrue(cache.toFile().list().length == 1);
+        assertTrue(Files.exists(LayoutUtils.getFeaturePackDir(cache, fpl.getFPID(), true)));
+        assertEquals(lastUsage, cli.getSession().getPmConfiguration().getLayoutCacheContent().getProperty(fpl.getFPID().toString()));
+
+        cli.execute("feature-pack clear-cache");
+        assertFalse(Files.exists(cache));
+        assertTrue(cli.getSession().getPmConfiguration().getLayoutCacheContent().isEmpty());
+
+        // SNAPSHOT MUST BE OVERWRITTEN each time.
+        FeaturePackLocation fplSnapshot = CliTestUtils.buildFPL(universeSpec, PRODUCER1, "1", "alpha", "1.0.0.Alpha1-SNAPSHOT");
+        Path snapshotPath = cli.newDir("install-snapshot", false);
+        cli.execute("install " + fplSnapshot
+                + " --dir=" + snapshotPath);
+        String time1 = cli.getSession().getPmConfiguration().getLayoutCacheContent().getProperty(fplSnapshot.getFPID().toString());
+        assertNotNull(time1);
+        cli.execute("install " + fplSnapshot
+                + " --dir=" + snapshotPath);
+        String time2 = cli.getSession().getPmConfiguration().getLayoutCacheContent().getProperty(fplSnapshot.getFPID().toString());
+        assertNotNull(time2);
+        assertFalse(time1.equals(time2));
+    }
+}

--- a/testsuite/src/test/java/org/jboss/galleon/cli/CliWrapper.java
+++ b/testsuite/src/test/java/org/jboss/galleon/cli/CliWrapper.java
@@ -16,11 +16,11 @@
  */
 package org.jboss.galleon.cli;
 
-import com.google.common.io.Files;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import org.aesh.command.CommandException;
 import org.aesh.command.CommandNotFoundException;
@@ -45,7 +45,7 @@ public class CliWrapper {
     final ByteArrayOutputStream out = new ByteArrayOutputStream();
     public CliWrapper() throws Exception {
         userHome = System.getProperty("user.home");
-        testUserHome = Files.createTempDir();
+        testUserHome = Files.createTempDirectory("galleon-cli-user-home-").toFile();
         System.setProperty("user.home", testUserHome.getAbsolutePath());
         // This is the default repository if no repository has been set.
         mvnRepo = new File(testUserHome, ".m2" + File.separator + "repository");


### PR DESCRIPTION
- Cache of feature-pack
- CLI to manage cache.
- Removed part of plugin options caching done in CLI.
- Automatic removal of old content from cache.
- Prepare for non interactive mode.
- New cache related tests.