### PR TITLE
Fix for GAL-123, non interactive console support

### DIFF
--- a/cli/src/main/java/org/jboss/galleon/cli/Arguments.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/Arguments.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.galleon.cli;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+public class Arguments {
+
+    public static final String HELP = "--help";
+    public static final String SCRIPT_FILE = "--file=";
+
+    private boolean isHelp;
+    private Map<String, String> options = Collections.emptyMap();
+    private String command;
+    private String scriptFile;
+
+    private Arguments() {
+    }
+
+    public boolean isHelp() {
+        return isHelp;
+    }
+
+    public String getCommand() {
+        return command;
+    }
+
+    public String getScriptFile() {
+        return scriptFile;
+    }
+
+    public Map<String, String> getOptions() {
+        return options;
+    }
+
+    public static Arguments parseArguments(String[] args) {
+        Arguments arguments = new Arguments();
+        if (args == null || args.length == 0) {
+            return arguments;
+        }
+        Map<String, String> opts = new HashMap<>();
+        int i = 0;
+        for (i = 0; i < args.length; i++) {
+            String arg = args[i];
+            if (arg.startsWith("--")) {
+                if (HELP.equals(arg)) {
+                    arguments.isHelp = true;
+                    return arguments;
+                }
+                if (arg.startsWith(SCRIPT_FILE)) {
+                    int sep = arg.indexOf("=");
+                    arguments.scriptFile = arg.substring(sep + 1);
+                    continue;
+                }
+                if (arg.contains("=")) {
+                    int sep = arg.indexOf("=");
+                    String opt = arg.substring(2, sep);
+                    String val = arg.substring(sep + 1);
+                    opts.put(opt, val);
+                } else {
+                    opts.put(arg.substring(2, arg.length()), null);
+                }
+            } else {
+                // Done for options.
+                break;
+            }
+        }
+        arguments.options = Collections.unmodifiableMap(opts);
+
+        // remaining args are command.
+        StringBuilder builder = new StringBuilder();
+        for (; i < args.length; i++) {
+            String cmd = args[i];
+            builder.append(cmd).append(" ");
+        }
+        arguments.command = builder.length() == 0 ? null : builder.toString().trim();
+
+        return arguments;
+    }
+}

--- a/cli/src/main/java/org/jboss/galleon/cli/PmSession.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/PmSession.java
@@ -31,8 +31,6 @@ import org.aesh.command.activator.OptionActivator;
 import org.aesh.command.activator.OptionActivatorProvider;
 import org.aesh.command.completer.CompleterInvocation;
 import org.aesh.command.completer.CompleterInvocationProvider;
-import org.aesh.command.invocation.CommandInvocation;
-import org.aesh.command.invocation.CommandInvocationProvider;
 import org.aesh.readline.AeshContext;
 import org.aesh.readline.Prompt;
 import org.aesh.utils.Config;
@@ -62,7 +60,7 @@ import org.jboss.galleon.universe.maven.repo.MavenRepoManager;
  *
  * @author Alexey Loubyansky
  */
-public class PmSession implements CommandInvocationProvider<PmCommandInvocation>, CompleterInvocationProvider<PmCompleterInvocation>,
+public class PmSession implements CompleterInvocationProvider<PmCompleterInvocation>,
         CommandActivatorProvider, OptionActivatorProvider<OptionActivator> {
 
     private class CliOverwritePolicy implements OverwritePolicy {
@@ -264,6 +262,7 @@ public class PmSession implements CommandInvocationProvider<PmCommandInvocation>
     private final CliOverwritePolicy policy = new CliOverwritePolicy();
     private final boolean interactive;
     private final FeaturePackCacheManager cacheManager;
+
     public PmSession(Configuration config) throws Exception {
         this(config, true);
     }
@@ -513,17 +512,16 @@ public class PmSession implements CommandInvocationProvider<PmCommandInvocation>
         return Paths.get(aeshCtx.getCurrentWorkingDirectory().getAbsolutePath());
     }
 
-    @Override
-    public PmCommandInvocation enhanceCommandInvocation(CommandInvocation commandInvocation) {
-        return new PmCommandInvocation(this, out, err, commandInvocation);
-    }
-
     void setOut(PrintStream out) {
         this.out = out;
     }
 
     void setErr(PrintStream err) {
         this.err = err;
+    }
+
+    PrintStream getErr() {
+        return err;
     }
 
     @Override

--- a/cli/src/main/java/org/jboss/galleon/cli/PmSessionCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/PmSessionCommand.java
@@ -47,6 +47,10 @@ public abstract class PmSessionCommand implements Command<PmCommandInvocation> {
             throw new CommandException(t);
         }
         // t.printStackTrace();
+        printException(session.getPmSession(), t);
+    }
+
+    static void printException(PmSession session, Throwable t) {
         if (t instanceof RuntimeException) {
             t.printStackTrace(session.getErr());
         }
@@ -82,7 +86,7 @@ public abstract class PmSessionCommand implements Command<PmCommandInvocation> {
         return t;
     }
 
-    private static void println(PmCommandInvocation session, Throwable t) {
+    private static void println(PmSession session, Throwable t) {
         if(t.getLocalizedMessage() == null) {
             session.println(t.getClass().getName());
         } else {

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/CliErrors.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/CliErrors.java
@@ -52,6 +52,10 @@ public interface CliErrors {
         return failed("Display content");
     }
 
+    static String emptyOption(String opt) {
+        return "Empty option " + opt;
+    }
+
     static String enterFPFailed() {
         return failed("Enter feature-pack");
     }
@@ -123,6 +127,11 @@ public interface CliErrors {
     static String newStateFailed() {
         return failed("Create new state");
     }
+
+    static String notFile(String absolutePath) {
+        return "Not a file: " + absolutePath;
+    }
+
 
     static String provisioningFailed() {
         return failed("Provisioning");
@@ -202,6 +211,10 @@ public interface CliErrors {
 
     static String uninstallFailed() {
         return failed("Uninstall");
+    }
+
+    static String unknownFile(String absolutePath) {
+        return "File " + absolutePath + " doesn't exist";
     }
 
     static String updateFailed() {

--- a/cli/src/main/java/org/jboss/galleon/cli/config/Configuration.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/config/Configuration.java
@@ -26,6 +26,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Properties;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
@@ -135,6 +137,10 @@ public class Configuration implements MavenChangeListener {
     }
 
     public static Configuration parse() throws ProvisioningException {
+        return parse(Collections.emptyMap());
+    }
+
+    public static Configuration parse(Map<String, String> options) throws ProvisioningException {
         Configuration config = new Configuration();
         Path configFile = getConfigFile();
         if (Files.exists(configFile)) {

--- a/cli/src/main/java/org/jboss/galleon/cli/terminal/CliShell.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/terminal/CliShell.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.galleon.cli.terminal;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.function.Consumer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.aesh.command.shell.Shell;
+import org.aesh.io.Encoder;
+import org.aesh.readline.Prompt;
+import org.aesh.readline.Readline;
+import org.aesh.readline.action.ActionDecoder;
+import org.aesh.readline.editing.EditModeBuilder;
+import org.aesh.readline.terminal.Key;
+import org.aesh.readline.tty.terminal.TerminalConnection;
+import org.aesh.terminal.Attributes;
+import org.aesh.terminal.Terminal;
+import org.aesh.terminal.tty.Capability;
+import org.aesh.terminal.tty.Size;
+import org.aesh.utils.Config;
+import org.jboss.galleon.cli.PmSession;
+
+/**
+ * A shell to handle ANSI and reading input from terminal. This shell is
+ * attached to a not started terminal connection that is started stopped when
+ * input reading is required.
+ *
+ * @author jdenise@redhat.com
+ */
+class CliShell implements Shell {
+
+    private final Terminal terminal;
+    private final Consumer<int[]> stdOut;
+    private final TerminalConnection connection;
+    private final Readline readline;
+    CliShell(TerminalConnection connection) throws IOException {
+        this.connection = connection;
+        this.terminal = connection.getTerminal();
+        if (terminal.getCodePointConsumer() == null) {
+            stdOut = new Encoder(Charset.defaultCharset(), this::write);
+        } else {
+            stdOut = terminal.getCodePointConsumer();
+        }
+        readline = new Readline(EditModeBuilder.builder().create());
+    }
+
+    public void close() throws IOException {
+        terminal.close();
+    }
+
+    private void write(byte[] data) {
+        try {
+            terminal.output().write(data);
+        } catch (IOException ex) {
+            Logger.getLogger(PmSession.class.getName()).log(Level.SEVERE, null, ex);
+        }
+    }
+
+    @Override
+    public void write(String msg, boolean paging) {
+        stdOut.accept(msg.codePoints().toArray());
+    }
+
+    @Override
+    public void writeln(String msg, boolean paging) {
+        stdOut.accept((msg + Config.getLineSeparator()).codePoints().toArray());
+    }
+
+    @Override
+    public void write(int[] out) {
+        stdOut.accept(out);
+    }
+
+    @Override
+    public void write(char out) {
+        stdOut.accept(new int[]{out});
+    }
+
+    @Override
+    public String readLine() throws InterruptedException {
+        return readLine(new Prompt(""));
+    }
+
+    @Override
+    public String readLine(Prompt prompt) throws InterruptedException {
+        final String[] out = {null};
+        readline.readline(connection, prompt, event -> {
+            out[0] = event;
+            connection.stopReading();
+        });
+        try {
+            connection.openBlocking();
+        } finally {
+            connection.setStdinHandler(null);
+        }
+        return out[0];
+    }
+
+    @Override
+    public Key read() throws InterruptedException {
+        ActionDecoder decoder = new ActionDecoder();
+        final Key[] key = {null};
+        Attributes attributes = connection.enterRawMode();
+        try {
+            connection.setStdinHandler(keys -> {
+                decoder.add(keys);
+                if (decoder.hasNext()) {
+                    key[0] = Key.findStartKey(decoder.next().buffer().array());
+                    connection.stopReading();
+                }
+            });
+            try {
+                connection.openBlocking();
+            } finally {
+                connection.setStdinHandler(null);
+            }
+        } finally {
+            connection.setAttributes(attributes);
+        }
+        return key[0];
+    }
+
+    @Override
+    public Key read(Prompt prompt) throws InterruptedException {
+        return null;
+    }
+
+    @Override
+    public boolean enableAlternateBuffer() {
+        return connection.put(Capability.enter_ca_mode);
+    }
+
+    @Override
+    public boolean enableMainBuffer() {
+        return connection.put(Capability.exit_ca_mode);
+    }
+
+    @Override
+    public Size size() {
+        return connection.size();
+    }
+
+    @Override
+    public void clear() {
+        connection.put(Capability.clear_screen);
+    }
+
+}

--- a/cli/src/main/java/org/jboss/galleon/cli/terminal/CliShellInvocationProvider.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/terminal/CliShellInvocationProvider.java
@@ -14,23 +14,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.galleon.cli;
+package org.jboss.galleon.cli.terminal;
 
 import org.aesh.command.invocation.CommandInvocation;
+import org.aesh.command.invocation.CommandInvocationProvider;
+import org.jboss.galleon.cli.PmCommandInvocation;
+import org.jboss.galleon.cli.PmSession;
 
 /**
- * A CommandInvocation instance base class that provides access to a PmSession.
  *
- * @author Alexey Loubyansky
+ * @author jdenise@redhat.com
  */
-public abstract class PmCommandInvocation implements CommandInvocation {
+public class CliShellInvocationProvider implements CommandInvocationProvider<PmCommandInvocation> {
 
     private final PmSession session;
-    protected PmCommandInvocation(PmSession session) {
+    private final CliTerminalConnection connection;
+
+    public CliShellInvocationProvider(PmSession session, CliTerminalConnection connection) {
         this.session = session;
+        this.connection = connection;
     }
 
-    public PmSession getPmSession() {
-        return session;
+    @Override
+    public PmCommandInvocation enhanceCommandInvocation(CommandInvocation commandInvocation) {
+        return new CliShellPmCommandInvocation(session, connection.getShell(), commandInvocation);
     }
 }

--- a/cli/src/main/java/org/jboss/galleon/cli/terminal/CliShellPmCommandInvocation.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/terminal/CliShellPmCommandInvocation.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.galleon.cli.terminal;
+
+import java.io.IOException;
+import org.aesh.command.CommandException;
+import org.aesh.command.CommandNotFoundException;
+import org.aesh.command.Executor;
+import org.aesh.command.invocation.CommandInvocation;
+import org.aesh.command.invocation.CommandInvocationConfiguration;
+import org.aesh.command.parser.CommandLineParserException;
+import org.aesh.command.shell.Shell;
+import org.aesh.command.validator.CommandValidatorException;
+import org.aesh.command.validator.OptionValidatorException;
+import org.aesh.readline.AeshContext;
+import org.aesh.readline.Prompt;
+import org.aesh.readline.action.KeyAction;
+import org.jboss.galleon.cli.PmCommandInvocation;
+import org.jboss.galleon.cli.PmSession;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+class CliShellPmCommandInvocation extends PmCommandInvocation {
+    private final Shell shell;
+    private final CommandInvocation delegate;
+
+    CliShellPmCommandInvocation(PmSession session, Shell shell, CommandInvocation delegate) {
+        super(session);
+        this.shell = shell;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Shell getShell() {
+        return shell;
+    }
+
+    @Override
+    public void setPrompt(Prompt prompt) {
+        delegate.setPrompt(prompt);
+    }
+
+    @Override
+    public Prompt getPrompt() {
+        return delegate.getPrompt();
+    }
+
+    @Override
+    public String getHelpInfo(String string) {
+        return delegate.getHelpInfo(string);
+    }
+
+    @Override
+    public void stop() {
+        // XXX jfdenise TODO!!!!
+    }
+
+    @Override
+    public AeshContext getAeshContext() {
+        return delegate.getAeshContext();
+    }
+
+    @Override
+    public CommandInvocationConfiguration getConfiguration() {
+        return delegate.getConfiguration();
+    }
+
+    @Override
+    public KeyAction input() throws InterruptedException {
+        return shell.read();
+    }
+
+    @Override
+    public String inputLine() throws InterruptedException {
+        return shell.readLine();
+    }
+
+    @Override
+    public String inputLine(Prompt prompt) throws InterruptedException {
+        return shell.readLine(prompt);
+    }
+
+    @Override
+    public void executeCommand(String string) throws CommandNotFoundException, CommandLineParserException, OptionValidatorException, CommandValidatorException, CommandException, InterruptedException, IOException {
+        delegate.executeCommand(string);
+    }
+
+    @Override
+    public Executor<? extends CommandInvocation> buildExecutor(String string) throws CommandNotFoundException, CommandLineParserException, OptionValidatorException, CommandValidatorException, IOException {
+        return delegate.buildExecutor(string);
+    }
+
+    @Override
+    public void print(String string, boolean bln) {
+        shell.write(string, bln);
+    }
+
+    @Override
+    public void println(String string, boolean bln) {
+        shell.writeln(string, bln);
+    }
+
+}

--- a/cli/src/main/java/org/jboss/galleon/cli/terminal/CliTerminalConnection.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/terminal/CliTerminalConnection.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.galleon.cli.terminal;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import org.aesh.command.shell.Shell;
+import org.aesh.readline.tty.terminal.TerminalConnection;
+import org.aesh.terminal.Connection;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+public class CliTerminalConnection {
+    private class CliOutputStream extends OutputStream {
+
+        @Override
+        public void write(int b) throws IOException {
+            connection.stdoutHandler().accept(new int[]{b});
+        }
+
+    }
+
+    private final TerminalConnection connection;
+    private final PrintStream out;
+    private final CliShell shell;
+
+    public CliTerminalConnection() throws IOException {
+        connection = new TerminalConnection();
+        out = new PrintStream(new CliOutputStream());
+        shell = new CliShell(connection);
+    }
+
+    public Connection getConnection() {
+        return connection;
+    }
+
+    public PrintStream getOutput() {
+        return out;
+    }
+
+    public Shell getShell() {
+        return shell;
+    }
+
+    public void close() {
+        connection.close();
+    }
+}

--- a/cli/src/main/java/org/jboss/galleon/cli/terminal/InteractiveInvocationProvider.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/terminal/InteractiveInvocationProvider.java
@@ -14,23 +14,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.galleon.cli;
+package org.jboss.galleon.cli.terminal;
 
 import org.aesh.command.invocation.CommandInvocation;
+import org.aesh.command.invocation.CommandInvocationProvider;
+import org.jboss.galleon.cli.PmCommandInvocation;
+import org.jboss.galleon.cli.PmSession;
 
 /**
- * A CommandInvocation instance base class that provides access to a PmSession.
  *
- * @author Alexey Loubyansky
+ * @author jdenise@redhat.com
  */
-public abstract class PmCommandInvocation implements CommandInvocation {
+public class InteractiveInvocationProvider implements CommandInvocationProvider<PmCommandInvocation> {
 
     private final PmSession session;
-    protected PmCommandInvocation(PmSession session) {
+
+    public InteractiveInvocationProvider(PmSession session) {
         this.session = session;
     }
 
-    public PmSession getPmSession() {
-        return session;
+    @Override
+    public PmCommandInvocation enhanceCommandInvocation(CommandInvocation commandInvocation) {
+        return new InteractivePmCommandInvocation(session, commandInvocation);
     }
 }

--- a/cli/src/main/java/org/jboss/galleon/cli/terminal/InteractivePmCommandInvocation.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/terminal/InteractivePmCommandInvocation.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.galleon.cli.terminal;
+
+import java.io.IOException;
+import org.aesh.command.CommandException;
+import org.aesh.command.CommandNotFoundException;
+import org.aesh.command.Executor;
+import org.aesh.command.invocation.CommandInvocation;
+import org.aesh.command.invocation.CommandInvocationConfiguration;
+import org.aesh.command.parser.CommandLineParserException;
+import org.aesh.command.shell.Shell;
+import org.aesh.command.validator.CommandValidatorException;
+import org.aesh.command.validator.OptionValidatorException;
+import org.aesh.readline.AeshContext;
+import org.aesh.readline.Prompt;
+import org.aesh.readline.action.KeyAction;
+import org.jboss.galleon.cli.PmCommandInvocation;
+import org.jboss.galleon.cli.PmSession;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+class InteractivePmCommandInvocation extends PmCommandInvocation {
+
+    private final CommandInvocation delegate;
+
+    InteractivePmCommandInvocation(PmSession session, CommandInvocation delegate) {
+        super(session);
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Shell getShell() {
+        return delegate.getShell();
+    }
+
+    @Override
+    public void setPrompt(Prompt prompt) {
+        delegate.setPrompt(prompt);
+    }
+
+    @Override
+    public Prompt getPrompt() {
+        return delegate.getPrompt();
+    }
+
+    @Override
+    public String getHelpInfo(String commandName) {
+        return delegate.getHelpInfo(commandName);
+    }
+
+    @Override
+    public void stop() {
+        delegate.stop();
+    }
+
+    @Override
+    public AeshContext getAeshContext() {
+        return delegate.getAeshContext();
+    }
+
+    @Override
+    public void print(String msg) {
+        delegate.print(msg);
+
+    }
+
+    @Override
+    public void println(String msg) {
+        delegate.println(msg);
+    }
+
+    @Override
+    public CommandInvocationConfiguration getConfiguration() {
+        return delegate.getConfiguration();
+    }
+
+    @Override
+    public KeyAction input() throws InterruptedException {
+        return delegate.input();
+
+    }
+
+    @Override
+    public String inputLine() throws InterruptedException {
+        return delegate.inputLine();
+    }
+
+    @Override
+    public String inputLine(Prompt prompt) throws InterruptedException {
+        return delegate.inputLine(prompt);
+    }
+
+    @Override
+    public void executeCommand(String input) throws CommandNotFoundException, CommandLineParserException, OptionValidatorException, CommandValidatorException, CommandException, InterruptedException, IOException {
+        delegate.executeCommand(input);
+    }
+
+    @Override
+    public Executor<? extends CommandInvocation> buildExecutor(String line) throws CommandNotFoundException, CommandLineParserException, OptionValidatorException, CommandValidatorException, IOException {
+        return delegate.buildExecutor(line);
+    }
+
+    @Override
+    public void print(String msg, boolean paging) {
+        delegate.print(msg, paging);
+    }
+
+    @Override
+    public void println(String msg, boolean paging) {
+        delegate.println(msg, paging);
+    }
+}

--- a/cli/src/main/java/org/jboss/galleon/cli/terminal/OutputInvocationProvider.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/terminal/OutputInvocationProvider.java
@@ -14,23 +14,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.galleon.cli;
+package org.jboss.galleon.cli.terminal;
 
 import org.aesh.command.invocation.CommandInvocation;
+import org.aesh.command.invocation.CommandInvocationProvider;
+import org.jboss.galleon.cli.PmCommandInvocation;
+import org.jboss.galleon.cli.PmSession;
 
 /**
- * A CommandInvocation instance base class that provides access to a PmSession.
+ * Used by tests.
  *
- * @author Alexey Loubyansky
+ * @author jdenise@redhat.com
  */
-public abstract class PmCommandInvocation implements CommandInvocation {
+public class OutputInvocationProvider implements CommandInvocationProvider<PmCommandInvocation> {
 
     private final PmSession session;
-    protected PmCommandInvocation(PmSession session) {
+
+    public OutputInvocationProvider(PmSession session) {
         this.session = session;
     }
 
-    public PmSession getPmSession() {
-        return session;
+    @Override
+    public PmCommandInvocation enhanceCommandInvocation(CommandInvocation commandInvocation) {
+        return new OutputPmCommandInvocation(session, commandInvocation);
     }
 }

--- a/cli/src/main/java/org/jboss/galleon/cli/terminal/OutputPmCommandInvocation.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/terminal/OutputPmCommandInvocation.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.galleon.cli.terminal;
+
+import java.io.IOException;
+import org.aesh.command.CommandException;
+import org.aesh.command.CommandNotFoundException;
+import org.aesh.command.Executor;
+import org.aesh.command.invocation.CommandInvocation;
+import org.aesh.command.invocation.CommandInvocationConfiguration;
+import org.aesh.command.parser.CommandLineParserException;
+import org.aesh.command.shell.Shell;
+import org.aesh.command.validator.CommandValidatorException;
+import org.aesh.command.validator.OptionValidatorException;
+import org.aesh.readline.AeshContext;
+import org.aesh.readline.Prompt;
+import org.aesh.readline.action.KeyAction;
+import org.jboss.galleon.cli.PmCommandInvocation;
+import org.jboss.galleon.cli.PmSession;
+
+/**
+ * Used by tests.
+ *
+ * @author jdenise@redhat.com
+ */
+class OutputPmCommandInvocation extends PmCommandInvocation {
+
+    private final CommandInvocation delegate;
+    OutputPmCommandInvocation(PmSession session, CommandInvocation delegate) {
+        super(session);
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Shell getShell() {
+        return delegate.getShell();
+    }
+
+    @Override
+    public void setPrompt(Prompt prompt) {
+        delegate.setPrompt(prompt);
+    }
+
+    @Override
+    public Prompt getPrompt() {
+        return delegate.getPrompt();
+    }
+
+    @Override
+    public String getHelpInfo(String commandName) {
+        return delegate.getHelpInfo(commandName);
+    }
+
+    @Override
+    public void stop() {
+        delegate.stop();
+    }
+
+    @Override
+    public AeshContext getAeshContext() {
+        return delegate.getAeshContext();
+    }
+
+    @Override
+    public void print(String msg) {
+        getPmSession().print(msg);
+
+    }
+
+    @Override
+    public void println(String msg) {
+        getPmSession().println(msg);
+    }
+
+    @Override
+    public CommandInvocationConfiguration getConfiguration() {
+        return delegate.getConfiguration();
+    }
+
+    @Override
+    public KeyAction input() throws InterruptedException {
+        return delegate.input();
+
+    }
+
+    @Override
+    public String inputLine() throws InterruptedException {
+        return delegate.inputLine();
+    }
+
+    @Override
+    public String inputLine(Prompt prompt) throws InterruptedException {
+        return delegate.inputLine(prompt);
+    }
+
+    @Override
+    public void executeCommand(String input) throws CommandNotFoundException, CommandLineParserException, OptionValidatorException, CommandValidatorException, CommandException, InterruptedException, IOException {
+        delegate.executeCommand(input);
+    }
+
+    @Override
+    public Executor<? extends CommandInvocation> buildExecutor(String line) throws CommandNotFoundException, CommandLineParserException, OptionValidatorException, CommandValidatorException, IOException {
+        return delegate.buildExecutor(line);
+    }
+
+    @Override
+    public void print(String msg, boolean paging) {
+        getPmSession().print(msg);
+    }
+
+    @Override
+    public void println(String msg, boolean paging) {
+        getPmSession().println(msg);
+    }
+}

--- a/cli/src/test/java/org/jboss/galleon/cli/ArgumentsTestCase.java
+++ b/cli/src/test/java/org/jboss/galleon/cli/ArgumentsTestCase.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.galleon.cli;
+
+import java.util.HashMap;
+import java.util.Map;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+public class ArgumentsTestCase {
+    @Test
+    public void test() {
+        {
+            Arguments args = Arguments.parseArguments(null);
+            assertNull(args.getCommand());
+            assertTrue(args.getOptions().isEmpty());
+            assertFalse(args.isHelp());
+        }
+        {
+            Arguments args = Arguments.parseArguments(new String[0]);
+            assertNull(args.getCommand());
+            assertTrue(args.getOptions().isEmpty());
+            assertFalse(args.isHelp());
+        }
+        {
+            String[] arr = {Arguments.HELP};
+            Arguments args = Arguments.parseArguments(arr);
+            assertTrue(args.isHelp());
+        }
+        {
+            String[] arr = {Arguments.SCRIPT_FILE + "foo-file.cli"};
+            Arguments args = Arguments.parseArguments(arr);
+            assertEquals("foo-file.cli", args.getScriptFile());
+        }
+        {
+            String[] arr = {Arguments.HELP, "foo"};
+            Arguments args = Arguments.parseArguments(arr);
+            assertTrue(args.isHelp());
+        }
+        {
+            Map<String, String> expected = new HashMap<>();
+            expected.put("opt1", null);
+            expected.put("opt2", "foo");
+            String[] arr = {"--opt1", "--opt2=foo", "foo", "--bar", "arg"};
+            Arguments args = Arguments.parseArguments(arr);
+            assertEquals(args.getCommand(), "foo --bar arg");
+            assertEquals(expected, args.getOptions());
+            assertFalse(args.isHelp());
+        }
+        {
+            String[] arr = {"foo", "--bar", "--arg"};
+            Arguments args = Arguments.parseArguments(arr);
+            assertEquals(args.getCommand(), "foo --bar --arg");
+            assertTrue(args.getOptions().isEmpty());
+            assertFalse(args.isHelp());
+        }
+        {
+            Map<String, String> expected = new HashMap<>();
+            expected.put("opt1", null);
+            String[] arr = {"--opt1"};
+            Arguments args = Arguments.parseArguments(arr);
+            assertNull(args.getCommand());
+            assertEquals(expected, args.getOptions());
+            assertFalse(args.isHelp());
+        }
+
+    }
+}

--- a/content/bin/galleon.sh
+++ b/content/bin/galleon.sh
@@ -22,20 +22,6 @@ DEBUG_MODE="${DEBUG:-false}"
 DEBUG_PORT="${DEBUG_PORT:-8787}"
 GREP="grep"
 
-while [ "$#" -gt 0 ]
-do
-    case "$1" in
-      --debug)
-          DEBUG_MODE=true
-          if [ -n "$2" ] && [ "$2" = `echo "$2" | sed 's/-//'` ]; then
-              DEBUG_PORT=$2
-              shift
-          fi
-          ;;
-    esac
-    shift
-done
-
 # Set debug settings if not already set
 if [ "$DEBUG_MODE" = "true" ]; then
     DEBUG_OPT=`echo $JAVA_OPTS | $GREP "\-agentlib:jdwp"`
@@ -54,5 +40,4 @@ if [ "x$JAVA" = "x" ]; then
         JAVA="java"
     fi
 fi
-
 exec "$JAVA" $JAVA_OPTS -jar "$DIRNAME"/galleon-cli.jar "$@"

--- a/do.sh
+++ b/do.sh
@@ -39,6 +39,9 @@ do
      run)
           unset BUILD
           ;;
+     *)
+          ARGS="$ARGS $1"
+          ;;
     esac
     shift
 done
@@ -58,5 +61,5 @@ if [[ -n $BUILD ]]; then
 fi
 
 if [[ -n $RUN ]]; then
-java $JAVA_OPTS -jar ./cli/target/galleon-cli-3.0.0.Alpha1-SNAPSHOT.jar
+java $JAVA_OPTS -jar ./cli/target/galleon-cli-3.0.0.Alpha1-SNAPSHOT.jar $ARGS
 fi

--- a/docs/guide/tool/state.adoc
+++ b/docs/guide/tool/state.adoc
@@ -3,6 +3,10 @@ This command line tool (_bin/galleon.[sh|bat]_) allows you to provision/manage a
 Although being a generic tool, a builtin support is offered for products available from maven jboss community universe (eg: wildfly). +
 Possible actions that you can operate from the tool: install, uninstall, check for updates, patch, update, undo last provisioning command.
 
+Launching the tool without any argument starts an interactive shell. Type _exit_ to exit the tool. +
+Launching the tool with a command as argument will execute the command and exit, eg: _galleon.sh install wildfly-core:current --dir=myinstallation_ +
+Launching the tool with _--file=<path to script file>_ will execute the set of commands and exit.
+
 ### Feature-pack
 A key concept in galleon system is the notion of feature-pack. A feature-pack is a content container. It can be a full product (eg: wildfly) 
 or part of a product (eg: a wildfly subsystem packaged as a feature-pack). With the tool you are going to install/uninstall/update/... feature-packs. +

--- a/pom.xml
+++ b/pom.xml
@@ -70,8 +70,8 @@
     <version.junit>4.12</version.junit>
     <version.maven-aether-provider>3.3.9</version.maven-aether-provider>
     <version.maven-settings-builder>3.3.9</version.maven-settings-builder>
-    <version.org.aesh>1.5</version.org.aesh>
-    <version.org.aesh-extensions>1.3</version.org.aesh-extensions>
+    <version.org.aesh>1.7</version.org.aesh>
+    <version.org.aesh-extensions>1.6</version.org.aesh-extensions>
     <version.org.apache.maven>3.3.1</version.org.apache.maven>
     <version.org.apache.maven.plugin-tools>${version.plugin.plugin}</version.org.apache.maven.plugin-tools>
     <version.org.apache.maven.plugins.maven-shade-plugin>3.1.0</version.org.apache.maven.plugins.maven-shade-plugin>


### PR DESCRIPTION
- Command as argument
- File of commands
- Reworked aesh integration to offer the proper Invocation context according to the execution context: interactive console, non interactive console, tests. This has the benefit to offer advanced terminal  capabilities (ANSI and read input) on all platforms  when run with non interactive console.
 - Evolved aesh dependency to latest released one 1.7. Still planned to upgrade to 1.8 to solve known issues.