### PR TITLE
Fix for GAL-128, CLI, support ~ in paths

### DIFF
--- a/cli/src/main/java/org/jboss/galleon/cli/CliMain.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/CliMain.java
@@ -16,9 +16,9 @@
  */
 package org.jboss.galleon.cli;
 
-import java.io.File;
 import java.io.PrintStream;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import org.jboss.galleon.cli.config.Configuration;
 import java.util.logging.LogManager;
@@ -100,17 +100,13 @@ public class CliMain {
                 if (file.isEmpty()) {
                     throw new Exception(CliErrors.emptyOption(Arguments.SCRIPT_FILE));
                 }
-                File f = new File(file);
-                if (!f.isAbsolute()) {
-                    String parent = runtime.getAeshContext().getCurrentWorkingDirectory().getAbsolutePath();
-                    f = new File(parent, file);
+                Path f = Util.resolvePath(pmSession.getAeshContext(), file);
+                if (!Files.exists(f)) {
+                    throw new Exception(CliErrors.unknownFile(f.toString()));
+                } else if (!Files.isRegularFile(f)) {
+                    throw new Exception(CliErrors.notFile(f.toString()));
                 }
-                if (!f.exists()) {
-                    throw new Exception(CliErrors.unknownFile(f.getAbsolutePath()));
-                } else if (!f.isFile()) {
-                    throw new Exception(CliErrors.notFile(f.getAbsolutePath()));
-                }
-                List<String> commands = Files.readAllLines(f.toPath());
+                List<String> commands = Files.readAllLines(f);
                 for (String cmd : commands) {
                     if (cmd.startsWith("#")) {
                         continue;

--- a/cli/src/main/java/org/jboss/galleon/cli/Util.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/Util.java
@@ -18,7 +18,10 @@ package org.jboss.galleon.cli;
 
 import java.io.InputStream;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
+import org.aesh.command.impl.converter.FileConverter;
+import org.aesh.readline.AeshContext;
 import org.aesh.readline.util.Parser;
 
 import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
@@ -76,5 +79,10 @@ public class Util {
         String[] array = new String[lst.size()];
         lst.toArray(array);
         return Parser.formatDisplayList(array, width, height);
+    }
+
+    public static Path resolvePath(AeshContext ctx, String path) {
+        Path workDir = PmSession.getWorkDir(ctx);
+        return Paths.get(FileConverter.translatePath(workDir.toString(), path));
     }
 }

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/installation/AddUniverseCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/installation/AddUniverseCommand.java
@@ -16,9 +16,9 @@
  */
 package org.jboss.galleon.cli.cmd.installation;
 
+import java.io.File;
 import java.io.IOException;
 import org.aesh.command.CommandDefinition;
-import org.aesh.command.impl.completer.FileOptionCompleter;
 import org.aesh.command.option.Option;
 import org.jboss.galleon.ProvisioningException;
 import org.jboss.galleon.cli.CommandExecutionException;
@@ -36,9 +36,9 @@ import org.jboss.galleon.cli.cmd.state.StateAddUniverseCommand;
 @CommandDefinition(name = "add-universe", description = HelpDescriptions.ADD_UNIVERSE)
 public class AddUniverseCommand extends StateAddUniverseCommand {
 
-    @Option(name = DIR_OPTION_NAME, completer = FileOptionCompleter.class, required = false,
+    @Option(name = DIR_OPTION_NAME, required = false,
             description = HelpDescriptions.INSTALLATION_DIRECTORY)
-    protected String targetDirArg;
+    protected File targetDirArg;
 
     @Override
     protected void runCommand(PmCommandInvocation commandInvocation) throws CommandExecutionException {

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/installation/ClearHistoryCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/installation/ClearHistoryCommand.java
@@ -34,7 +34,7 @@ public class ClearHistoryCommand extends AbstractInstallationCommand {
     @Override
     protected void runCommand(PmCommandInvocation invoc) throws CommandExecutionException {
         try {
-            ProvisioningManager mgr = invoc.getPmSession().newProvisioningManager(getInstallationDirectory(invoc.getAeshContext()), false);
+            ProvisioningManager mgr = getManager(invoc.getPmSession());
             mgr.clearStateHistory();
         } catch (ProvisioningException ex) {
             throw new CommandExecutionException(invoc.getPmSession(), CliErrors.clearHistoryFailed(), ex);

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/installation/ExportCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/installation/ExportCommand.java
@@ -17,14 +17,12 @@
 package org.jboss.galleon.cli.cmd.installation;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import org.aesh.command.CommandDefinition;
-import org.aesh.command.impl.completer.FileOptionCompleter;
 import org.aesh.command.option.Argument;
-import org.aesh.io.Resource;
 import org.jboss.galleon.ProvisioningException;
 import org.jboss.galleon.cli.CommandExecutionException;
 import org.jboss.galleon.cli.HelpDescriptions;
@@ -40,15 +38,14 @@ import org.jboss.galleon.xml.ProvisioningXmlWriter;
 @CommandDefinition(name = "export", description = HelpDescriptions.EXPORT)
 public class ExportCommand extends AbstractInstallationCommand {
 
-    @Argument(completer = FileOptionCompleter.class, required = false,
+    @Argument(required = false,
             description = HelpDescriptions.EXPORT_FILE)
-    private Resource file;
+    private File file;
 
     @Override
     protected void runCommand(PmCommandInvocation invoc) throws CommandExecutionException {
         if (file != null) {
-            final Resource specResource = file.resolve(invoc.getAeshContext().getCurrentWorkingDirectory()).get(0);
-            final Path targetFile = Paths.get(specResource.getAbsolutePath());
+            final Path targetFile = file.toPath();
             try {
                 getManager(invoc.getPmSession()).exportProvisioningConfig(targetFile);
             } catch (ProvisioningException | IOException e) {

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/installation/RemoveUniverseCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/installation/RemoveUniverseCommand.java
@@ -16,9 +16,9 @@
  */
 package org.jboss.galleon.cli.cmd.installation;
 
+import java.io.File;
 import java.io.IOException;
 import org.aesh.command.CommandDefinition;
-import org.aesh.command.impl.completer.FileOptionCompleter;
 import org.aesh.command.option.Option;
 import org.jboss.galleon.ProvisioningException;
 import org.jboss.galleon.cli.CommandExecutionException;
@@ -36,9 +36,9 @@ import org.jboss.galleon.cli.cmd.state.StateRemoveUniverseCommand;
 @CommandDefinition(name = "remove-universe", description = HelpDescriptions.REMOVE_UNIVERSE)
 public class RemoveUniverseCommand extends StateRemoveUniverseCommand {
 
-    @Option(name = DIR_OPTION_NAME, completer = FileOptionCompleter.class, required = false,
+    @Option(name = DIR_OPTION_NAME, required = false,
             description = HelpDescriptions.INSTALLATION_DIRECTORY)
-    protected String targetDirArg;
+    protected File targetDirArg;
     @Override
     protected void runCommand(PmCommandInvocation commandInvocation) throws CommandExecutionException {
         try {

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/maingrp/CheckUpdatesCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/maingrp/CheckUpdatesCommand.java
@@ -70,7 +70,7 @@ public class CheckUpdatesCommand extends AbstractProvisioningCommand {
     @Override
     protected void runCommand(PmCommandInvocation session) throws CommandExecutionException {
         try {
-            ProvisioningManager mgr = getManager(session.getPmSession());
+            ProvisioningManager mgr = getManager(session.getPmSession(), false);
 
             Updates updates = getUpdatesTable(mgr, session, includeAll, fp);
             if (updates.plan.isEmpty()) {

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/maingrp/InstallCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/maingrp/InstallCommand.java
@@ -40,6 +40,7 @@ import org.jboss.galleon.cli.resolver.PluginResolver;
 import org.jboss.galleon.cli.PmCommandActivator;
 import org.jboss.galleon.cli.PmCommandInvocation;
 import org.jboss.galleon.cli.PmSession;
+import org.jboss.galleon.cli.Util;
 import org.jboss.galleon.cli.cmd.CliErrors;
 import org.jboss.galleon.cli.cmd.CommandDomain;
 import org.jboss.galleon.cli.cmd.plugin.AbstractPluginsCommand;
@@ -86,8 +87,7 @@ public class InstallCommand extends AbstractPluginsCommand {
             String filePath = (String) getValue(FILE_OPTION_NAME);
             final ProvisioningManager manager = getManager(session);
             if (filePath != null) {
-                Path workDir = PmSession.getWorkDir(session.getAeshContext());
-                Path p = workDir.resolve(filePath);
+                Path p = Util.resolvePath(session.getAeshContext(), filePath);
                 // always install for future use.
                 manager.install(p, true);
             } else {
@@ -162,8 +162,7 @@ public class InstallCommand extends AbstractPluginsCommand {
         if (filePath == null) {
             return super.getId(session);
         }
-        Path workDir = PmSession.getWorkDir(session.getAeshContext());
-        Path path = workDir.resolve(filePath);
+        Path path = Util.resolvePath(session.getAeshContext(), filePath);
         if (!Files.exists(path)) {
             return null;
         }
@@ -190,8 +189,7 @@ public class InstallCommand extends AbstractPluginsCommand {
         if (arg != null) {
             throw new CommandExecutionException("Only one of file or Feature-pack location is allowed.");
         }
-        Path workDir = PmSession.getWorkDir(invoc.getAeshContext());
-        Path p = workDir.resolve(filePath);
+        Path p = Util.resolvePath(invoc.getAeshContext(), filePath);
         if (!Files.exists(p)) {
             throw new CommandExecutionException(p + " doesn't exist.");
         }
@@ -217,7 +215,7 @@ public class InstallCommand extends AbstractPluginsCommand {
     protected Path getInstallationHome(AeshContext context) {
         String targetDirArg = (String) getValue(DIR_OPTION_NAME);
         Path workDir = PmSession.getWorkDir(context);
-        return targetDirArg == null ? workDir : workDir.resolve(targetDirArg);
+        return targetDirArg == null ? workDir : Util.resolvePath(context, targetDirArg);
     }
 
     @Override

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/maingrp/ProvisionCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/maingrp/ProvisionCommand.java
@@ -18,7 +18,6 @@ package org.jboss.galleon.cli.cmd.maingrp;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -102,7 +101,7 @@ public class ProvisionCommand extends AbstractProvisionCommand {
     protected void doValidateOptions(PmCommandInvocation invoc) throws CommandExecutionException {
         String filePath = getFile();
         if (filePath != null) {
-            if (!Files.exists(Paths.get(filePath))) {
+            if (!Files.exists(getAbsolutePath(filePath, invoc.getAeshContext()))) {
                 throw new CommandExecutionException(filePath + " doesn't exist");
             }
         }

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/maingrp/UndoCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/maingrp/UndoCommand.java
@@ -16,7 +16,6 @@
  */
 package org.jboss.galleon.cli.cmd.maingrp;
 
-import java.nio.file.Path;
 import org.aesh.command.CommandDefinition;
 import org.aesh.command.option.Option;
 import org.jboss.galleon.ProvisioningException;
@@ -41,9 +40,7 @@ public class UndoCommand extends AbstractProvisioningCommand {
     @Override
     protected void runCommand(PmCommandInvocation invoc) throws CommandExecutionException {
         try {
-
-            Path p = getInstallationDirectory(invoc.getAeshContext());
-            ProvisioningManager mgr = invoc.getPmSession().newProvisioningManager(p, verbose);
+            ProvisioningManager mgr = getManager(invoc.getPmSession(), verbose);
             mgr.undo();
         } catch (ProvisioningException ex) {
             throw new CommandExecutionException(invoc.getPmSession(), CliErrors.undoFailed(), ex);

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/maingrp/UpdateCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/maingrp/UpdateCommand.java
@@ -109,8 +109,7 @@ public class UpdateCommand extends AbstractProvisionWithPlugins {
             // Check in argument or option, that is the option completion case.
             targetDirArg = getOptionValue(DIR_OPTION_NAME);
         }
-        Path workDir = PmSession.getWorkDir(pmSession.getAeshContext());
-        Path installation = targetDirArg == null ? workDir : workDir.resolve(targetDirArg);
+        Path installation = getAbsolutePath(targetDirArg, pmSession.getAeshContext());
         ProvisioningConfig config = pmSession.newProvisioningManager(installation, false).getProvisioningConfig();
         Set<PluginOption> opts = pmSession.getResolver().get(null, PluginResolver.newResolver(pmSession, config)).getDiff();
         List<DynamicOption> options = new ArrayList<>();

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/plugin/AbstractProvisionWithPlugins.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/plugin/AbstractProvisionWithPlugins.java
@@ -34,6 +34,7 @@ import org.jboss.galleon.cli.HelpDescriptions;
 import org.jboss.galleon.cli.PmCommandActivator;
 import org.jboss.galleon.cli.PmCommandInvocation;
 import org.jboss.galleon.cli.PmSession;
+import org.jboss.galleon.cli.Util;
 import org.jboss.galleon.cli.cmd.AbstractDynamicCommand;
 import org.jboss.galleon.cli.cmd.CommandWithInstallationDirectory;
 import static org.jboss.galleon.cli.cmd.maingrp.AbstractProvisioningCommand.DIR_OPTION_NAME;
@@ -76,7 +77,7 @@ public abstract class AbstractProvisionWithPlugins extends AbstractDynamicComman
         return contains(VERBOSE_OPTION_NAME);
     }
 
-    protected String getDir() {
+    private String getDir() {
         return (String) getValue(DIR_OPTION_NAME);
     }
 
@@ -90,8 +91,7 @@ public abstract class AbstractProvisionWithPlugins extends AbstractDynamicComman
     }
 
     protected Path getAbsolutePath(String path, AeshContext context) {
-        Path workDir = PmSession.getWorkDir(context);
-        return path == null ? PmSession.getWorkDir(context) : workDir.resolve(path);
+        return path == null ? PmSession.getWorkDir(context) : Util.resolvePath(context, path);
     }
 
     protected abstract void doRunCommand(PmCommandInvocation session, Map<String, String> options) throws CommandExecutionException;

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/state/StateEditCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/state/StateEditCommand.java
@@ -16,10 +16,10 @@
  */
 package org.jboss.galleon.cli.cmd.state;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import org.aesh.command.CommandDefinition;
-import org.aesh.command.impl.completer.FileOptionCompleter;
 import org.aesh.command.option.Argument;
 import org.aesh.readline.AeshContext;
 import org.jboss.galleon.ProvisioningException;
@@ -38,9 +38,9 @@ import org.jboss.galleon.cli.model.state.State;
  */
 @CommandDefinition(name = "edit", description = HelpDescriptions.EDIT_STATE)
 public class StateEditCommand extends PmSessionCommand {
-    @Argument(completer = FileOptionCompleter.class, required = false,
+    @Argument(required = false,
             description = HelpDescriptions.EDIT_STATE_ARG)
-    protected String dir;
+    protected File dir;
 
     @Override
     protected void runCommand(PmCommandInvocation invoc) throws CommandExecutionException {
@@ -56,8 +56,7 @@ public class StateEditCommand extends PmSessionCommand {
     }
 
     protected Path getInstallationHome(AeshContext context) {
-        Path workDir = PmSession.getWorkDir(context);
-        return dir == null ? PmSession.getWorkDir(context) : workDir.resolve(dir);
+        return dir == null ? PmSession.getWorkDir(context) : dir.toPath();
     }
 
 }

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/state/StateExportCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/state/StateExportCommand.java
@@ -17,13 +17,11 @@
 package org.jboss.galleon.cli.cmd.state;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.PrintWriter;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import org.aesh.command.CommandDefinition;
-import org.aesh.command.impl.completer.FileOptionCompleter;
 import org.aesh.command.option.Argument;
-import org.aesh.io.Resource;
 import org.jboss.galleon.cli.CommandExecutionException;
 import org.jboss.galleon.cli.HelpDescriptions;
 import org.jboss.galleon.cli.PmCommandInvocation;
@@ -41,15 +39,14 @@ import org.jboss.galleon.xml.ProvisioningXmlWriter;
 @CommandDefinition(name = "export", description = HelpDescriptions.EXPORT_STATE)
 public class StateExportCommand extends PmSessionCommand {
 
-    @Argument(completer = FileOptionCompleter.class, required = false,
+    @Argument(required = false,
             description = HelpDescriptions.EXPORT_FILE)
-    private Resource file;
+    private File file;
 
     @Override
     protected void runCommand(PmCommandInvocation invoc) throws CommandExecutionException {
         if (file != null) {
-            final Resource specResource = file.resolve(invoc.getAeshContext().getCurrentWorkingDirectory()).get(0);
-            final Path targetFile = Paths.get(specResource.getAbsolutePath());
+            final Path targetFile = file.toPath();
             State session = invoc.getPmSession().getState();
             try {
                 session.export(targetFile);


### PR DESCRIPTION
- Use builtin aesh support when possible (static commands).
- Rely on aesh file converter for dynamic commands.
- Added some File/dir existence checks.
- Removed some redundancy.
