### PR TITLE
[GAL-136] Arguments in wrong order

### DIFF
--- a/cli/src/main/java/org/jboss/galleon/cli/PmCommandInvocation.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/PmCommandInvocation.java
@@ -37,7 +37,7 @@ public abstract class PmCommandInvocation implements CommandInvocation {
 
     public String formatColumns(List<String> lst) {
         return Util.formatColumns(lst,
-                getShell().size().getHeight(),
-                getShell().size().getWidth());
+                getShell().size().getWidth(),
+                getShell().size().getHeight());
     }
 }

--- a/cli/src/main/java/org/jboss/galleon/cli/Util.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/Util.java
@@ -78,7 +78,7 @@ public class Util {
     public static String formatColumns(List<String> lst, int width, int height) {
         String[] array = new String[lst.size()];
         lst.toArray(array);
-        return Parser.formatDisplayList(array, width, height);
+        return Parser.formatDisplayList(array, height, width);
     }
 
     public static Path resolvePath(AeshContext ctx, String path) {

--- a/core/src/main/java/org/jboss/galleon/creator/tasks/StringToFile.java
+++ b/core/src/main/java/org/jboss/galleon/creator/tasks/StringToFile.java
@@ -31,7 +31,7 @@ class StringToFile extends RelativeTargetTask {
     private final boolean isContent;
 
      protected StringToFile(String content, String relativeTarget) {
-        this(relativeTarget, content, true);
+        this(content, relativeTarget, true);
     }
 
     protected StringToFile(String content, String relativeTarget, boolean isContent) {

--- a/core/src/main/java/org/jboss/galleon/diff/FileSystemDiff.java
+++ b/core/src/main/java/org/jboss/galleon/diff/FileSystemDiff.java
@@ -123,7 +123,7 @@ public class FileSystemDiff {
         private List<String> extractUnifiedDiff(Path revised, Path original) throws IOException {
             final List<String> revisedLines = Files.readAllLines(revised, StandardCharsets.UTF_8);
             final List<String> originalLines = Files.readAllLines(original, StandardCharsets.UTF_8);
-            Patch<String> patch = DiffUtils.diff(revisedLines, originalLines);
+            Patch<String> patch = DiffUtils.diff(originalLines, revisedLines);
             return DiffUtils.generateUnifiedDiff(revised.toString(), original.toString(), revisedLines, patch, 0);
         }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/GAL-136 - Arguments in wrong order

Methods signatures:
```
public static String formatColumns(List<String> lst, int width, int height) {
```
```
protected StringToFile(String content, String relativeTarget, boolean isContent) { 
```
```
public static <T> Patch<T> diff(List<T> original, List<T> revised) {
```

