### PR TITLE
Fix for GAL-151, CLI, --dir option not propagated when resolving FPL

### DIFF
--- a/cli/src/main/java/org/jboss/galleon/cli/PmSessionCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/PmSessionCommand.java
@@ -79,7 +79,7 @@ public abstract class PmSessionCommand implements Command<PmCommandInvocation> {
                 // Handle default and named universes
                 if (cex.getCause() instanceof LatestVersionNotAvailableException) {
                     LatestVersionNotAvailableException cause = (LatestVersionNotAvailableException) cex.getCause();
-                    FeaturePackLocation fpl = cex.getPmSession().getExposedLocation(cause.getLocation());
+                    FeaturePackLocation fpl = cex.getPmSession().getExposedLocation(null, cause.getLocation());
                     t = new LatestVersionNotAvailableException(fpl);
                 }
             }

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/InstalledProducerCompleter.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/InstalledProducerCompleter.java
@@ -61,12 +61,16 @@ public class InstalledProducerCompleter extends AbstractCommaSeparatedCompleter 
                 try (ProvisioningLayout<FeaturePackLayout> layout = mgr.getLayoutFactory().newConfigLayout(mgr.getProvisioningConfig())) {
                     for (FeaturePackLayout fp : layout.getOrderedFeaturePacks()) {
                         if (fp.isDirectDep() || (fp.isTransitiveDep() && transitive)) {
-                            items.add(completerInvocation.getPmSession().getExposedLocation(fp.getFPID().getLocation()));
+                            items.add(completerInvocation.getPmSession().
+                                    getExposedLocation(cmd.getInstallationDirectory(completerInvocation.
+                                            getAeshContext()), fp.getFPID().getLocation()));
                         }
                         if (patches) {
                             List<FeaturePackLayout> appliedPatches = layout.getPatches(fp.getFPID());
                             for (FeaturePackLayout patch : appliedPatches) {
-                                items.add(completerInvocation.getPmSession().getExposedLocation(patch.getFPID().getLocation()));
+                                items.add(completerInvocation.getPmSession().
+                                        getExposedLocation(cmd.getInstallationDirectory(completerInvocation.
+                                                getAeshContext()), patch.getFPID().getLocation()));
                             }
                         }
                     }

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/featurepack/GetInfoCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/featurepack/GetInfoCommand.java
@@ -84,7 +84,7 @@ public class GetInfoCommand extends AbstractFeaturePackCommand {
             try {
                 if (fpl != null) {
                     FeaturePackLocation loc;
-                    loc = session.getResolvedLocation(fpl);
+                    loc = session.getResolvedLocation(null, fpl);
                     FeaturePackConfig config = FeaturePackConfig.forLocation(loc);
                     provisioning = ProvisioningConfig.builder().addFeaturePackDep(config).build();
                     layout = session.getLayoutFactory().newConfigLayout(provisioning);
@@ -107,14 +107,15 @@ public class GetInfoCommand extends AbstractFeaturePackCommand {
                 if (isProduct) {
                     product = fpLayout;
                 } else {
-                    dependencies.add(session.getExposedLocation(fpLayout.getFPID().getLocation()));
+                    dependencies.add(session.getExposedLocation(null, fpLayout.getFPID().getLocation()));
                 }
             }
             if (product == null) {
                 throw new CommandExecutionException("No feature-pack found");
             }
 
-            StateInfoUtil.printFeaturePack(commandInvocation, product.getFPID().getLocation());
+            StateInfoUtil.printFeaturePack(commandInvocation,
+                    session.getExposedLocation(null, product.getFPID().getLocation()));
 
             FPID patchFor = product.getSpec().getPatchFor();
             if (patchFor != null) {

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/installation/AddUniverseCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/installation/AddUniverseCommand.java
@@ -43,7 +43,9 @@ public class AddUniverseCommand extends StateAddUniverseCommand {
     @Override
     protected void runCommand(PmCommandInvocation commandInvocation) throws CommandExecutionException {
         try {
-            commandInvocation.getPmSession().getUniverse().addUniverse(targetDirArg, name, factory, location);
+            commandInvocation.getPmSession().getUniverse().
+                    addUniverse(targetDirArg == null ? null : targetDirArg.toPath(),
+                            name, factory, location);
         } catch (IOException | ProvisioningException ex) {
             throw new CommandExecutionException(commandInvocation.getPmSession(), CliErrors.addUniverseFailed(), ex);
         }

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/installation/RemoveUniverseCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/installation/RemoveUniverseCommand.java
@@ -42,7 +42,8 @@ public class RemoveUniverseCommand extends StateRemoveUniverseCommand {
     @Override
     protected void runCommand(PmCommandInvocation commandInvocation) throws CommandExecutionException {
         try {
-            commandInvocation.getPmSession().getUniverse().removeUniverse(targetDirArg, name);
+            commandInvocation.getPmSession().getUniverse().
+                    removeUniverse(targetDirArg == null ? null : targetDirArg.toPath(), name);
         } catch (IOException | ProvisioningException ex) {
             throw new CommandExecutionException(commandInvocation.getPmSession(), CliErrors.removeUniverseFailed(), ex);
         }

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/maingrp/CheckUpdatesCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/maingrp/CheckUpdatesCommand.java
@@ -98,7 +98,9 @@ public class CheckUpdatesCommand extends AbstractProvisioningCommand {
             String[] split = fp.split(",+");
             ProducerSpec[] resolved = new ProducerSpec[split.length];
             for (int i = 0; i < split.length; i++) {
-                resolved[i] = session.getPmSession().getResolvedLocation(split[i]).getProducer();
+                resolved[i] = session.getPmSession().
+                        getResolvedLocation(mgr.getInstallationHome(),
+                                split[i]).getProducer();
             }
             plan = mgr.getUpdates(resolved);
         }

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/maingrp/FindCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/maingrp/FindCommand.java
@@ -69,7 +69,7 @@ public class FindCommand extends PmSessionCommand {
             Integer[] numResults = new Integer[1];
             numResults[0] = 0;
             try {
-                Comparator locComparator = new Comparator<FeaturePackLocation>() {
+                Comparator<FeaturePackLocation> locComparator = new Comparator<FeaturePackLocation>() {
                     @Override
                     public int compare(FeaturePackLocation o1, FeaturePackLocation o2) {
                         return o1.toString().compareTo(o2.toString());
@@ -81,7 +81,7 @@ public class FindCommand extends PmSessionCommand {
                         // Universe could have been set in the pattern, matches on
                         // the canonical and exposed (named universe).
                         FeaturePackLocation exposedLoc = invoc.getPmSession().
-                                getExposedLocation(loc);
+                                getExposedLocation(null, loc);
                         boolean canonicalMatch = compiledPattern.matcher(loc.toString()).matches();
                         boolean exposedMatch = compiledPattern.matcher(exposedLoc.toString()).matches();
                         // Frequency has been set, only matches FPL that contains a frequency.
@@ -125,7 +125,8 @@ public class FindCommand extends PmSessionCommand {
 
                 for (Entry<UniverseSpec, Set<FeaturePackLocation>> entry : results.entrySet()) {
                     UniverseSpec universeSpec = entry.getKey();
-                    String universeName = invoc.getPmSession().getUniverse().getUniverseName(universeSpec);
+                    String universeName = invoc.getPmSession().getUniverse().
+                            getUniverseName(null, universeSpec);
                     universeName = universeName == null ? universeSpec.toString() : universeName;
                     invoc.println(Config.getLineSeparator() + "Universe "
                             + universeName

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/maingrp/GetInfoCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/maingrp/GetInfoCommand.java
@@ -57,7 +57,8 @@ public class GetInfoCommand extends AbstractProvisioningCommand {
                     }
                 }
             };
-            StateInfoUtil.displayInfo(invoc, config, type, supplier);
+            StateInfoUtil.displayInfo(invoc, getInstallationDirectory(invoc.
+                    getConfiguration().getAeshContext()), config, type, supplier);
         } catch (ProvisioningException | CommandExecutionException ex) {
             throw new CommandExecutionException(invoc.getPmSession(), CliErrors.infoFailed(), ex);
         }

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/maingrp/InstallCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/maingrp/InstallCommand.java
@@ -212,7 +212,7 @@ public class InstallCommand extends AbstractPluginsCommand {
     }
 
     @Override
-    protected Path getInstallationHome(AeshContext context) {
+    public Path getInstallationDirectory(AeshContext context) {
         String targetDirArg = (String) getValue(DIR_OPTION_NAME);
         Path workDir = PmSession.getWorkDir(context);
         return targetDirArg == null ? workDir : Util.resolvePath(context, targetDirArg);

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/maingrp/ListFeaturePacksCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/maingrp/ListFeaturePacksCommand.java
@@ -69,7 +69,7 @@ public class ListFeaturePacksCommand extends PmSessionCommand {
                         table = new Table(Headers.PRODUCT, Headers.UPDATE_CHANNEL, Headers.LATEST_BUILD);
                         tables.put(loc.getUniverse(), table);
                     }
-                    loc = invoc.getPmSession().getExposedLocation(loc);
+                    loc = invoc.getPmSession().getExposedLocation(null, loc);
                     table.addLine(producer.getName(), StateInfoUtil.formatChannel(loc),
                             (loc.getBuild() == null ? NONE : loc.getBuild()));
                 }
@@ -95,7 +95,7 @@ public class ListFeaturePacksCommand extends PmSessionCommand {
         FindCommand.printExceptions(invoc, exceptions);
         for (Entry<UniverseSpec, Table> entry : tables.entrySet()) {
             UniverseSpec universeSpec = entry.getKey();
-            String universeName = invoc.getPmSession().getUniverse().getUniverseName(universeSpec);
+            String universeName = invoc.getPmSession().getUniverse().getUniverseName(null, universeSpec);
             universeName = universeName == null ? universeSpec.toString() : universeName;
             invoc.println(Config.getLineSeparator() + "Universe " + universeName
                     + Config.getLineSeparator());

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/maingrp/UninstallCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/maingrp/UninstallCommand.java
@@ -86,7 +86,7 @@ public class UninstallCommand extends AbstractProvisionWithPlugins {
             throw new CommandExecutionException("No feature-pack provided");
         }
         try {
-            return session.getResolvedLocation(fpid).getFPID();
+            return session.getResolvedLocation(getInstallationDirectory(session.getAeshContext()), fpid).getFPID();
         } catch (Exception e) {
             throw new CommandExecutionException(session, CliErrors.resolveLocationFailed(), e);
         }
@@ -120,12 +120,17 @@ public class UninstallCommand extends AbstractProvisionWithPlugins {
             // Silent resolution.
             pmSession.unregisterTrackers();
             try {
-                try (ProvisioningLayout<FeaturePackLayout> layout = pmSession.getLayoutFactory().newConfigLayout(config)) {
-                    layout.uninstall(pmSession.getResolvedLocation(fpid).getFPID());
-                    Set<PluginOption> opts = PluginResolver.newResolver(pmSession, layout).resolve().getInstall();
+                try (ProvisioningLayout<FeaturePackLayout> layout = pmSession.
+                        getLayoutFactory().newConfigLayout(config)) {
+                    layout.uninstall(pmSession.
+                            getResolvedLocation(getInstallationDirectory(pmSession.
+                                    getAeshContext()), fpid).getFPID());
+                    Set<PluginOption> opts = PluginResolver.newResolver(pmSession,
+                            layout).resolve().getInstall();
                     List<DynamicOption> options = new ArrayList<>();
                     for (PluginOption opt : opts) {
-                        DynamicOption dynOption = new DynamicOption(opt.getName(), opt.isRequired(), opt.isAcceptsValue());
+                        DynamicOption dynOption = new DynamicOption(opt.getName(),
+                                opt.isRequired(), opt.isAcceptsValue());
                         options.add(dynOption);
                     }
                     return options;

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/mvn/MavenResolveFeaturePack.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/mvn/MavenResolveFeaturePack.java
@@ -47,7 +47,7 @@ public class MavenResolveFeaturePack extends PmSessionCommand {
                 session.getPmSession().enableMavenTrace(true);
             }
             try {
-                session.getPmSession().downloadFp(session.getPmSession().getResolvedLocation(fpl).getFPID());
+                session.getPmSession().downloadFp(session.getPmSession().getResolvedLocation(null, fpl).getFPID());
                 session.println("artifact installed in local mvn repository " + session.getPmSession().
                         getPmConfiguration().getMavenConfig().getLocalRepository());
             } finally {

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/plugin/DiffCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/plugin/DiffCommand.java
@@ -118,7 +118,7 @@ public class DiffCommand extends AbstractPluginsCommand {
     }
 
     @Override
-    protected Path getInstallationHome(AeshContext context) {
+    public Path getInstallationDirectory(AeshContext context) {
         final String srcPath = (String) getValue(SRC_NAME);
         return srcPath == null ? PmSession.getWorkDir(context) : toPath(srcPath, context);
     }

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/state/AbstractFPProvisioningCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/state/AbstractFPProvisioningCommand.java
@@ -38,7 +38,7 @@ public abstract class AbstractFPProvisioningCommand extends AbstractStateCommand
 
     @Override
     protected void runCommand(PmCommandInvocation invoc, State session) throws IOException, ProvisioningException, CommandExecutionException {
-        FeaturePackLocation fpl = invoc.getPmSession().getResolvedLocation(this.fpl);
+        FeaturePackLocation fpl = invoc.getPmSession().getResolvedLocation(null, this.fpl);
         runCommand(invoc, session, fpl);
     }
 

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/state/StateGetInfoCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/state/StateGetInfoCommand.java
@@ -50,7 +50,7 @@ public class StateGetInfoCommand extends PmSessionCommand {
                     return invoc.getPmSession().getState().getContainer();
                 }
             };
-            StateInfoUtil.displayInfo(invoc, config, type, supplier);
+            StateInfoUtil.displayInfo(invoc, null, config, type, supplier);
         } catch (Exception ex) {
             throw new CommandExecutionException(invoc.getPmSession(), CliErrors.infoFailed(), ex);
         }

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/state/StateRemoveUniverseCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/state/StateRemoveUniverseCommand.java
@@ -43,7 +43,7 @@ public class StateRemoveUniverseCommand extends PmSessionCommand {
         @Override
         protected List<String> getItems(PmCompleterInvocation completerInvocation) {
             List<String> names = new ArrayList<>();
-            names.addAll(completerInvocation.getPmSession().getUniverse().getUniverseNames());
+            names.addAll(completerInvocation.getPmSession().getUniverse().getUniverseNames(null));
             return names;
         }
     }

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/state/configuration/AbstractDefaultConfigCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/state/configuration/AbstractDefaultConfigCommand.java
@@ -142,7 +142,7 @@ public abstract class AbstractDefaultConfigCommand extends AbstractFPProvisioned
             return null;
         }
         try {
-            return session.getResolvedLocation(origin).getProducer();
+            return session.getResolvedLocation(null, origin).getProducer();
         } catch (ProvisioningException ex) {
             throw new CommandExecutionException(session, CliErrors.retrieveProducerFailed(), ex);
         }

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/state/configuration/AbstractProvisionedDefaultConfigCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/state/configuration/AbstractProvisionedDefaultConfigCommand.java
@@ -124,7 +124,7 @@ public abstract class AbstractProvisionedDefaultConfigCommand extends AbstractFP
             return null;
         }
         try {
-            return session.getResolvedLocation(origin).getProducer();
+            return session.getResolvedLocation(null, origin).getProducer();
         } catch (ProvisioningException ex) {
             throw new CommandExecutionException(session, CliErrors.retrieveProducerFailed(), ex);
         }

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/state/fp/StateRemoveFeaturePackCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/state/fp/StateRemoveFeaturePackCommand.java
@@ -48,7 +48,7 @@ public class StateRemoveFeaturePackCommand extends AbstractStateCommand {
             if (session != null) {
                 for (FeaturePackConfig fp : session.getConfig().getFeaturePackDeps()) {
                     String loc = completerInvocation.getPmSession().
-                            getExposedLocation(fp.getLocation()).toString();
+                            getExposedLocation(null, fp.getLocation()).toString();
                     lst.add(loc);
                 }
             }
@@ -61,7 +61,7 @@ public class StateRemoveFeaturePackCommand extends AbstractStateCommand {
 
     @Override
     protected void runCommand(PmCommandInvocation invoc, State session) throws IOException, ProvisioningException, CommandExecutionException {
-        session.removeDependency(invoc.getPmSession(), invoc.getPmSession().getResolvedLocation(fpl));
+        session.removeDependency(invoc.getPmSession(), invoc.getPmSession().getResolvedLocation(null, fpl));
     }
 
     @Override

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/state/pkg/AbstractProvisionedPackageCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/state/pkg/AbstractProvisionedPackageCommand.java
@@ -114,7 +114,7 @@ public abstract class AbstractProvisionedPackageCommand extends AbstractFPProvis
             return null;
         }
         try {
-            return session.getResolvedLocation(origin).getProducer();
+            return session.getResolvedLocation(null, origin).getProducer();
         } catch (ProvisioningException ex) {
             throw new CommandExecutionException(session, CliErrors.retrieveProducerFailed(), ex);
         }

--- a/cli/src/main/java/org/jboss/galleon/cli/tracking/BuildLayoutTracker.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/tracking/BuildLayoutTracker.java
@@ -35,7 +35,7 @@ public class BuildLayoutTracker extends CliProgressTracker<FPID> {
 
     @Override
     protected String processingContent(ProgressTracker<FPID> tracker) {
-        return session.getExposedLocation(tracker.getItem().getLocation()).toString();
+        return session.getExposedLocation(null, tracker.getItem().getLocation()).toString();
     }
 
     @Override

--- a/cli/src/main/java/org/jboss/galleon/cli/tracking/UpdatesTracker.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/tracking/UpdatesTracker.java
@@ -35,7 +35,7 @@ public class UpdatesTracker extends CliProgressTracker<ProducerSpec> {
 
     @Override
     protected String processingContent(ProgressTracker<ProducerSpec> tracker) {
-        return session.getExposedLocation(tracker.getItem().getLocation()).toString();
+        return session.getExposedLocation(null, tracker.getItem().getLocation()).toString();
     }
 
     @Override

--- a/testsuite/src/test/java/org/jboss/galleon/cli/UniverseTestCase.java
+++ b/testsuite/src/test/java/org/jboss/galleon/cli/UniverseTestCase.java
@@ -75,13 +75,20 @@ public class UniverseTestCase {
 
         FeaturePackLocation toInstall2 = CliTestUtils.buildFPL(UniverseSpec.
                 fromString(UNIVERSE_CUSTOM_NAME), PRODUCER2, "1", null, null);
-        // Due to GAL-151, we must cd into the installation
-        cli.execute("filesystem cd " + dir);
+
         cli.execute("install " + toInstall2 + " --dir=" + dir);
 
         cli.execute("get-info --dir=" + dir);
         assertTrue(cli.getOutput(), cli.getOutput().contains(UNIVERSE_CUSTOM_NAME + "@1"));
 
+        FeaturePackLocation toUnInstall = CliTestUtils.buildFPL(UniverseSpec.
+                fromString(UNIVERSE_CUSTOM_NAME), PRODUCER2, "1", null, "1.0.0.Final");
+
+        cli.execute("uninstall " + toUnInstall + " --dir=" + dir);
+
+        cli.execute("undo --dir=" + dir);
+
+        cli.execute("filesystem cd " + dir);
         cli.execute("list-feature-packs");
         assertTrue(cli.getOutput(), cli.getOutput().contains(UNIVERSE_CUSTOM_NAME + "@1"));
 
@@ -102,6 +109,10 @@ public class UniverseTestCase {
         cli.execute("find " + PRODUCER2);
         assertFalse(cli.getOutput(), cli.getOutput().contains(CliTestUtils.buildFPL(UniverseSpec.
                 fromString(UNIVERSE_CUSTOM_NAME), PRODUCER2, "1", null, "1.0.0.Final").toString()));
+
+        // Only spec is now usable to reference universe.
+        FeaturePackLocation toUnInstall2 = CliTestUtils.buildFPL(universeSpec2, PRODUCER2, "1", null, "1.0.0.Final");
+        cli.execute("uninstall " + toUnInstall2 + " --dir=" + dir);
     }
 
 }


### PR DESCRIPTION
- Convey installation path in places where context sensitive information (eg: local universe names) are retrieved.