### PR TITLE
Fix for GAL-164, pattern in mvn mirror

### DIFF
--- a/cli/src/main/java/org/jboss/galleon/cli/Util.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/Util.java
@@ -67,7 +67,8 @@ public class Util {
         return session;
     }
 
-    static RepositorySystem newRepositorySystem() {
+    // public for testing purpose
+    public static RepositorySystem newRepositorySystem() {
         DefaultServiceLocator locator = MavenRepositorySystemUtils.newServiceLocator();
         locator.addService(RepositoryConnectorFactory.class, BasicRepositoryConnectorFactory.class);
         locator.addService(TransporterFactory.class, FileTransporterFactory.class);

--- a/cli/src/test/java/org/jboss/galleon/cli/config/mvn/MvnSettingsTestCase.java
+++ b/cli/src/test/java/org/jboss/galleon/cli/config/mvn/MvnSettingsTestCase.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.galleon.cli.config.mvn;
+
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.repository.Proxy;
+import org.eclipse.aether.repository.ProxySelector;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.jboss.galleon.cli.Util;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+public class MvnSettingsTestCase {
+
+    @Test
+    public void test() throws Exception {
+        RepositorySystem system = Util.newRepositorySystem();
+        MavenConfig config = new MavenConfig();
+        InputStream stream = MvnSettingsTestCase.class.getClassLoader().
+                getResourceAsStream("settings_cli_test.xml");
+        File tmp = File.createTempFile("cli_mvn_test", null);
+        tmp.deleteOnExit();
+        Files.copy(stream, tmp.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        config.setSettings(tmp.toPath());
+        MavenMvnSettings settings = new MavenMvnSettings(config, system, null);
+        assertEquals(settings.getRepositories().size(), 3);
+        boolean seen1 = false;
+        boolean seen2 = false;
+        boolean seen3 = false;
+        for (RemoteRepository remote : settings.getRepositories()) {
+            if (remote.getId().equals("repo1")) {
+                seen1 = true;
+                assertTrue(remote.getUrl().equals("http://repo1"));
+            }
+            if (remote.getId().equals("repo2")) {
+                seen2 = true;
+                assertTrue(remote.getUrl().equals("http://repo2"));
+            }
+            if (remote.getId().equals("repo3")) {
+                assertTrue(remote.getUrl().equals("http://repo3"));
+                seen3 = true;
+            }
+            assertNotNull(remote.getAuthentication());
+        }
+        assertTrue(seen1 && seen2 && seen3);
+    }
+
+    @Test
+    public void testMirror() throws Exception {
+        RepositorySystem system = Util.newRepositorySystem();
+        MavenConfig config = new MavenConfig();
+        InputStream stream = MvnSettingsTestCase.class.getClassLoader().
+                getResourceAsStream("settings_cli_test_mirror.xml");
+        File tmp = File.createTempFile("cli_mvn_test", null);
+        tmp.deleteOnExit();
+        Files.copy(stream, tmp.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        config.setSettings(tmp.toPath());
+        MavenMvnSettings settings = new MavenMvnSettings(config, system, null);
+        assertEquals(settings.getRepositories().size(), 2);
+        boolean seen3 = false;
+        boolean seenMirror = false;
+        for (RemoteRepository remote : settings.getRepositories()) {
+            if (remote.getId().equals("repo3")) {
+                seen3 = true;
+            }
+            if (remote.getId().equals("mirror1")) {
+                assertTrue(remote.getUrl().equals("http://mirror1"));
+                seenMirror = true;
+                assertEquals(remote.getMirroredRepositories().size(), 2);
+                boolean seen1 = false;
+                boolean seen2 = false;
+                for (RemoteRepository mirrored : remote.getMirroredRepositories()) {
+                    if (mirrored.getId().equals("repo1")) {
+                        seen1 = true;
+                        assertTrue(mirrored.getUrl(), mirrored.getUrl().equals("http://repo1"));
+                    }
+                    if (mirrored.getId().equals("repo2")) {
+                        seen2 = true;
+                        assertTrue(mirrored.getUrl(), mirrored.getUrl().equals("http://repo2"));
+                    }
+                }
+                assertTrue(seen1 && seen2);
+            }
+        }
+        assertTrue(seenMirror && seen3);
+    }
+
+    @Test
+    public void testMirrorAll() throws Exception {
+        RepositorySystem system = Util.newRepositorySystem();
+        MavenConfig config = new MavenConfig();
+        InputStream stream = MvnSettingsTestCase.class.getClassLoader().
+                getResourceAsStream("settings_cli_test_mirror_all.xml");
+        File tmp = File.createTempFile("cli_mvn_test", null);
+        tmp.deleteOnExit();
+        Files.copy(stream, tmp.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        config.setSettings(tmp.toPath());
+        MavenMvnSettings settings = new MavenMvnSettings(config, system, null);
+        assertEquals(settings.getRepositories().size(), 1);
+
+        boolean seenMirror = false;
+        for (RemoteRepository remote : settings.getRepositories()) {
+            if (remote.getId().equals("mirror1")) {
+                assertTrue(remote.getUrl().equals("http://mirror1"));
+                seenMirror = true;
+                assertEquals(remote.getMirroredRepositories().size(), 3);
+                boolean seen1 = false;
+                boolean seen2 = false;
+                boolean seen3 = false;
+                for (RemoteRepository mirrored : remote.getMirroredRepositories()) {
+                    if (mirrored.getId().equals("repo1")) {
+                        seen1 = true;
+                        assertTrue(mirrored.getUrl(), mirrored.getUrl().equals("http://repo1"));
+                    }
+                    if (mirrored.getId().equals("repo2")) {
+                        seen2 = true;
+                        assertTrue(mirrored.getUrl(), mirrored.getUrl().equals("http://repo2"));
+                    }
+                    if (mirrored.getId().equals("repo3")) {
+                        seen3 = true;
+                        assertTrue(mirrored.getUrl(), mirrored.getUrl().equals("http://repo3"));
+                    }
+                }
+                assertTrue(seen1 && seen2 && seen3);
+            }
+        }
+        assertTrue(seenMirror);
+    }
+
+    @Test
+    public void testProxy() throws Exception {
+        RepositorySystem system = Util.newRepositorySystem();
+        MavenConfig config = new MavenConfig();
+        InputStream stream = MvnSettingsTestCase.class.getClassLoader().
+                getResourceAsStream("settings_cli_test_proxy.xml");
+        File tmp = File.createTempFile("cli_mvn_test", null);
+        tmp.deleteOnExit();
+        Files.copy(stream, tmp.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        config.setSettings(tmp.toPath());
+        MavenMvnSettings settings = new MavenMvnSettings(config, system, null);
+        ProxySelector proxy = settings.getSession().getProxySelector();
+        assertEquals(settings.getRepositories().size(), 3);
+        for (RemoteRepository remote : settings.getRepositories()) {
+            if (remote.getId().equals("repo1")) {
+                assertNull(proxy.getProxy(remote));
+            }
+            if (remote.getId().equals("repo2")) {
+                assertNull(proxy.getProxy(remote));
+            }
+            if (remote.getId().equals("repo3")) {
+                Proxy p = proxy.getProxy(remote);
+                assertEquals("proxy1", p.getHost());
+            }
+        }
+    }
+}

--- a/cli/src/test/resources/settings_cli_test.xml
+++ b/cli/src/test/resources/settings_cli_test.xml
@@ -1,0 +1,87 @@
+<!--
+
+    Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server>
+      <id>repo1</id>
+      <username>user1</username>
+      <password>pwd1</password>
+    </server>
+    <server>
+      <id>repo2</id>
+      <username>user2</username>
+      <password>pwd2</password>
+    </server>
+    <server>
+      <id>repo3</id>
+      <username>user3</username>
+      <password>pwd3</password>
+    </server>
+  </servers>
+  <profiles>
+    <profile>
+      <id>profile1</id>
+      <repositories>
+        <repository>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+          <id>repo1</id>
+          <name>JBoss Repository</name>
+          <url>http://repo1</url>
+        </repository>
+        <repository>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+          <id>repo2</id>
+          <name>JBoss Repository</name>
+          <url>http://repo2</url>
+        </repository>
+        <repository>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+          <id>repo3</id>
+          <name>JBoss Repository</name>
+          <url>http://repo3</url>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+  <activeProfiles>
+    <activeProfile>profile1</activeProfile>
+  </activeProfiles>
+</settings>

--- a/cli/src/test/resources/settings_cli_test_mirror.xml
+++ b/cli/src/test/resources/settings_cli_test_mirror.xml
@@ -1,0 +1,95 @@
+<!--
+
+    Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server>
+      <id>repo1</id>
+      <username>user1</username>
+      <password>pwd1</password>
+    </server>
+    <server>
+      <id>repo2</id>
+      <username>user2</username>
+      <password>pwd2</password>
+    </server>
+    <server>
+      <id>repo3</id>
+      <username>user3</username>
+      <password>pwd3</password>
+    </server>
+  </servers>
+  <mirrors>
+    <mirror>
+      <id>mirror1</id>
+      <name>Maven Repository Manager running on repo.mycompany.com</name>
+      <url>http://mirror1</url>
+      <mirrorOf>*, !repo3</mirrorOf>
+    </mirror>
+  </mirrors>
+  <profiles>
+    <profile>
+      <id>profile1</id>
+      <repositories>
+        <repository>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+          <id>repo1</id>
+          <name>JBoss Repository</name>
+          <url>http://repo1</url>
+        </repository>
+        <repository>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+          <id>repo2</id>
+          <name>JBoss Repository</name>
+          <url>http://repo2</url>
+        </repository>
+        <repository>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+          <id>repo3</id>
+          <name>JBoss Repository</name>
+          <url>http://repo3</url>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+  <activeProfiles>
+    <activeProfile>profile1</activeProfile>
+  </activeProfiles>
+</settings>

--- a/cli/src/test/resources/settings_cli_test_mirror_all.xml
+++ b/cli/src/test/resources/settings_cli_test_mirror_all.xml
@@ -1,0 +1,95 @@
+<!--
+
+    Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server>
+      <id>repo1</id>
+      <username>user1</username>
+      <password>pwd1</password>
+    </server>
+    <server>
+      <id>repo2</id>
+      <username>user2</username>
+      <password>pwd2</password>
+    </server>
+    <server>
+      <id>repo3</id>
+      <username>user3</username>
+      <password>pwd3</password>
+    </server>
+  </servers>
+  <mirrors>
+    <mirror>
+      <id>mirror1</id>
+      <name>Maven Repository Manager running on repo.mycompany.com</name>
+      <url>http://mirror1</url>
+      <mirrorOf>*</mirrorOf>
+    </mirror>
+  </mirrors>
+  <profiles>
+    <profile>
+      <id>profile1</id>
+      <repositories>
+        <repository>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+          <id>repo1</id>
+          <name>JBoss Repository</name>
+          <url>http://repo1</url>
+        </repository>
+        <repository>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+          <id>repo2</id>
+          <name>JBoss Repository</name>
+          <url>http://repo2</url>
+        </repository>
+        <repository>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+          <id>repo3</id>
+          <name>JBoss Repository</name>
+          <url>http://repo3</url>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+  <activeProfiles>
+    <activeProfile>profile1</activeProfile>
+  </activeProfiles>
+</settings>

--- a/cli/src/test/resources/settings_cli_test_proxy.xml
+++ b/cli/src/test/resources/settings_cli_test_proxy.xml
@@ -1,0 +1,97 @@
+<!--
+
+    Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <proxies>
+    <proxy>
+      <id>example-proxy</id>
+      <active>true</active>
+      <protocol>http</protocol>
+      <host>proxy1</host>
+      <port>8080</port>
+      <nonProxyHosts>repo1|repo2</nonProxyHosts>
+    </proxy>
+  </proxies>
+  <servers>
+    <server>
+      <id>repo1</id>
+      <username>user1</username>
+      <password>pwd1</password>
+    </server>
+    <server>
+      <id>repo2</id>
+      <username>user2</username>
+      <password>pwd2</password>
+    </server>
+    <server>
+      <id>repo3</id>
+      <username>user3</username>
+      <password>pwd3</password>
+    </server>
+  </servers>
+  <profiles>
+    <profile>
+      <id>profile1</id>
+      <repositories>
+        <repository>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+          <id>repo1</id>
+          <name>JBoss Repository</name>
+          <url>http://repo1</url>
+        </repository>
+        <repository>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+          <id>repo2</id>
+          <name>JBoss Repository</name>
+          <url>http://repo2</url>
+        </repository>
+        <repository>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+          <id>repo3</id>
+          <name>JBoss Repository</name>
+          <url>http://repo3</url>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+  <activeProfiles>
+    <activeProfile>profile1</activeProfile>
+  </activeProfiles>
+</settings>


### PR DESCRIPTION
- Support for * and !<repo id>
- warn if external:* is used (not supported),
- added unit tests.