### PR TITLE
[GAL-170] [GAL-171] [GAL-172]

### DIFF
--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/state/StateInfoUtil.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/state/StateInfoUtil.java
@@ -339,7 +339,7 @@ public class StateInfoUtil {
         return null;
     }
 
-    public static String buildPatches(PmCommandInvocation invoc, ProvisioningLayout<FeaturePackLayout> layout) {
+    public static String buildPatches(PmCommandInvocation invoc, ProvisioningLayout<FeaturePackLayout> layout) throws ProvisioningException {
         if (!layout.hasPatches()) {
             return null;
         }

--- a/core/src/main/java/org/jboss/galleon/Constants.java
+++ b/core/src/main/java/org/jboss/galleon/Constants.java
@@ -22,6 +22,7 @@ package org.jboss.galleon;
  */
 public interface Constants {
 
+    String DOT_GLNEW = ".glnew";
     String DOT_XML = ".xml";
     String CONFIGS = "configs";
     String CONFIG_XML = "config.xml";
@@ -29,6 +30,7 @@ public interface Constants {
     String FEATURE_GROUPS = "feature_groups";
     String FEATURES = "features";
     String FEATURE_PACK_XML = "feature-pack.xml";
+    String HASHES = "hashes";
     String HISTORY = "history";
     String HISTORY_LIST = "list";
     String LAYERS = "layers";

--- a/core/src/main/java/org/jboss/galleon/Errors.java
+++ b/core/src/main/java/org/jboss/galleon/Errors.java
@@ -441,6 +441,10 @@ public interface Errors {
         return "Required dependency of configuration layer " + srcLayer + " on layer " + targetLayer + " was excluded";
     }
 
+    static String fsEntryInit(Path p) {
+        return "Failed to process child entries for " + p;
+    }
+
     static void appendConfig(final StringBuilder buf, String model, String name) {
         if (model != null) {
             buf.append(" model ").append(model);

--- a/core/src/main/java/org/jboss/galleon/diff/DiffRuntime.java
+++ b/core/src/main/java/org/jboss/galleon/diff/DiffRuntime.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.galleon.diff;
+
+import org.jboss.galleon.MessageWriter;
+
+/**
+ *
+ * @author Alexey Loubyansky
+ */
+public class DiffRuntime {
+
+    public static DiffRuntime newInstance(FsDiff diff, MessageWriter log) {
+        DiffRuntime diffRt = new DiffRuntime();
+        diffRt.diff = diff;
+        diffRt.log = log;
+        return diffRt;
+    }
+
+    private FsDiff diff;
+    private MessageWriter log;
+
+    private DiffRuntime() {
+    }
+}

--- a/core/src/main/java/org/jboss/galleon/diff/FsDiff.java
+++ b/core/src/main/java/org/jboss/galleon/diff/FsDiff.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.galleon.diff;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.galleon.ProvisioningException;
+import org.jboss.galleon.util.CollectionUtils;
+import org.jboss.galleon.util.StringUtils;
+
+/**
+ *
+ * @author Alexey Loubyansky
+ */
+public class FsDiff {
+
+    public static FsDiff diff(FsEntry original, FsEntry other) throws ProvisioningException {
+        return new FsDiff(original, other);
+    }
+
+    private final FsEntry original;
+    private final FsEntry other;
+    private Map<String, FsEntry> added = Collections.emptyMap();
+    private Map<String, FsEntry> removed = Collections.emptyMap();
+    private Map<String, FsEntry[]> modified = Collections.emptyMap();
+
+    private FsDiff(FsEntry original, FsEntry other) throws ProvisioningException {
+        this.original = original;
+        this.other = other;
+        doDiff(original, other);
+    }
+
+    private void doDiff(FsEntry originalEntry, FsEntry otherEntry) throws ProvisioningException {
+        if(originalEntry.isDir() != otherEntry.isDir()) {
+            removed = CollectionUtils.put(removed, originalEntry.getRelativePath(), originalEntry);
+            added = CollectionUtils.put(added, otherEntry.getRelativePath(), otherEntry);
+            return;
+        }
+        if(originalEntry.dir) {
+            final Map<String, FsEntry> otherChildren = otherEntry.cloneChildren();
+            if (originalEntry.hasChildren()) {
+                for (FsEntry originalChild : originalEntry.getChildren()) {
+                    final FsEntry otherChild = otherChildren.remove(originalChild.getName());
+                    if(otherChild == null) {
+                        removed = CollectionUtils.put(removed, originalChild.getRelativePath(), originalChild);
+                        continue;
+                    }
+                    doDiff(originalChild, otherChild);
+                }
+                if (!otherChildren.isEmpty()) {
+                    for (FsEntry otherChild : otherChildren.values()) {
+                        added = CollectionUtils.put(added, otherChild.getRelativePath(), otherChild);
+                    }
+                }
+            }
+            return;
+        }
+        if(!Arrays.equals(originalEntry.getHash(), otherEntry.getHash())) {
+            modified = CollectionUtils.put(modified, originalEntry.getRelativePath(), new FsEntry[] {originalEntry, otherEntry});
+        }
+    }
+
+    public boolean isEmpty() {
+        return modified.isEmpty() && added.isEmpty() && removed.isEmpty();
+    }
+
+    public boolean hasAddedEntries() {
+        return !added.isEmpty();
+    }
+
+    public Collection<FsEntry> getAddedEntries() {
+        return added.values();
+    }
+
+    public boolean hasRemovedEntries() {
+        return !removed.isEmpty();
+    }
+
+    public Collection<FsEntry> getRemovedEntries() {
+        return removed.values();
+    }
+
+    public boolean hasModifiedEntries() {
+        return !modified.isEmpty();
+    }
+
+    public Collection<FsEntry[]> getModifiedEntries() {
+        return modified.values();
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder buf = new StringBuilder();
+        buf.append('[');
+        List<String> names = null;
+        if(!added.isEmpty()) {
+            buf.append("added: ");
+            names = new ArrayList<>(added.keySet());
+            Collections.sort(names);
+            StringUtils.append(buf, names);
+        }
+        if(!removed.isEmpty()) {
+            if(buf.length() > 1) {
+                buf.append("; ");
+            }
+            buf.append("removed: ");
+            if(names == null) {
+                names = new ArrayList<>(removed.size());
+            } else {
+                names.clear();
+            }
+            names.addAll(removed.keySet());
+            Collections.sort(names);
+            StringUtils.append(buf, names);
+        }
+        if(!modified.isEmpty()) {
+            if(buf.length() > 1) {
+                buf.append("; ");
+            }
+            buf.append("modified: ");
+            if(names == null) {
+                names = new ArrayList<>(modified.size());
+            } else {
+                names.clear();
+            }
+            names.addAll(modified.keySet());
+            Collections.sort(names);
+            StringUtils.append(buf, names);
+        }
+        return buf.append(']').toString();
+    }
+}

--- a/core/src/main/java/org/jboss/galleon/diff/FsEntry.java
+++ b/core/src/main/java/org/jboss/galleon/diff/FsEntry.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.galleon.diff;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.galleon.Errors;
+import org.jboss.galleon.ProvisioningException;
+import org.jboss.galleon.util.CollectionUtils;
+import org.jboss.galleon.util.HashUtils;
+
+/**
+ * Represents a filesystem entry, i.e. a file or directory.
+ *
+ * @author Alexey Loubyansky
+ */
+public class FsEntry {
+
+    final int depth;
+    final FsEntry parent;
+    final Path p;
+    final String name;
+    final boolean dir;
+    private byte[] hash;
+
+    private Map<String, FsEntry> children = Collections.emptyMap();
+
+    public FsEntry(FsEntry parent, Path p) {
+        this.parent = parent;
+        this.p = p;
+        this.name = p.getFileName().toString();
+        this.dir = Files.isDirectory(p);
+        if(parent != null) {
+            depth = parent.depth + 1;
+            parent.addChild(this);
+        } else {
+            depth = 0;
+        }
+    }
+
+    public FsEntry(FsEntry parent, String name, byte[] hash) {
+        this.parent = parent;
+        this.name = name;
+        this.hash = hash;
+        this.dir = false;
+        this.p = null;
+        if(parent != null) {
+            depth = parent.depth + 1;
+            parent.addChild(this);
+        } else {
+            depth = 0;
+        }
+    }
+
+    private void addChild(FsEntry child) {
+        children = CollectionUtils.put(children, child.name, child);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getRelativePath() {
+        final StringBuilder buf = new StringBuilder();
+        collectPath(this, buf);
+        return buf.toString();
+    }
+
+    public Path getPath() {
+        return p;
+    }
+
+    private static void collectPath(FsEntry entry, StringBuilder buf) {
+        if(entry.parent == null) {
+            return;
+        }
+        collectPath(entry.parent, buf);
+        if(buf.length() > 0) {
+            buf.append('/');
+        }
+        buf.append(entry.getName());
+    }
+
+    public boolean isDir() {
+        return dir;
+    }
+
+    public boolean hasChildren() {
+        return !children.isEmpty();
+    }
+
+    public Collection<FsEntry> getChildren() {
+        return children.values();
+    }
+
+    public Map<String, FsEntry> cloneChildren() {
+        return children.isEmpty() ? Collections.emptyMap() : new HashMap<>(children);
+    }
+
+    public FsEntry getChild(String name) {
+        return children.get(name);
+    }
+
+    public boolean hasChild(String name) {
+        return children.containsKey(name);
+    }
+
+    public boolean includesPath(String relativePath) {
+        if(relativePath.charAt(0) == '/') {
+            relativePath = relativePath.substring(1);
+        }
+        return includesPath(relativePath.split("/"));
+    }
+
+    public boolean includesPath(String... pathElements) {
+        if(children.isEmpty()) {
+            return false;
+        }
+        FsEntry e = this;
+        for(int i = 0; i < pathElements.length; ++i) {
+            e = e.children.get(pathElements[i]);
+            if(e == null) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public byte[] getHash() throws ProvisioningException {
+        if(hash == null) {
+            try {
+                hash = HashUtils.hashPath(p);
+            } catch (IOException e) {
+                throw new ProvisioningException(Errors.hashCalculation(p));
+            }
+        }
+        return hash;
+    }
+
+    public void dumpAsTree(PrintStream out) throws IOException {
+        dumpAsTree(children.isEmpty() ? Collections.emptyList() : new ArrayList<>(), out);
+    }
+
+    private void dumpAsTree(List<Boolean> dirs, PrintStream out) throws IOException {
+        if(!dirs.isEmpty()) {
+            Boolean dir;
+            int i = 0;
+            while(i < dirs.size() - 1) {
+                dir = dirs.get(i++);
+                out.print(dir ? "| " : "  ");
+            }
+            dir = dirs.get(i);
+            out.print(dir ? "|-" : "`-");
+        }
+        out.print(name);
+        if(dir) {
+            out.print('/');
+        }
+        out.println();
+
+        if(!children.isEmpty()) {
+            final String[] names = children.keySet().toArray(new String[children.size()]);
+            Arrays.sort(names);
+            final int dirsI = dirs.size();
+            dirs.add(false);
+            int i = 0;
+            while(i < names.length) {
+                final String name = names[i++];
+                dirs.set(dirsI, i < names.length);
+                children.get(name).dumpAsTree(dirs, out);
+            }
+            dirs.remove(dirsI);
+        }
+    }
+}

--- a/core/src/main/java/org/jboss/galleon/diff/FsEntryFactory.java
+++ b/core/src/main/java/org/jboss/galleon/diff/FsEntryFactory.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.galleon.diff;
+
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.jboss.galleon.Errors;
+import org.jboss.galleon.ProvisioningException;
+import org.jboss.galleon.util.CollectionUtils;
+
+/**
+ * Factory that builds a representation of a filesystem branch
+ * possibly filtering out one or more of its subbranches.
+ *
+ * NOTE: this class is *NOT* thread-safe!
+ *
+ * @author Alexey Loubyansky
+ */
+public class FsEntryFactory {
+
+    private static class PathFilter {
+
+        final String[] pathElements;
+        final boolean relative;
+        final String suffix;
+
+        final FsEntry[] checkEntries;
+
+        PathFilter(String[] pathElements, boolean relative) {
+            this.pathElements = pathElements;
+            this.relative = relative;
+            if(pathElements.length > 0) {
+                String tmp = pathElements[pathElements.length - 1];
+                if(tmp.charAt(0) == '*') {
+                    tmp = tmp.substring(1);
+                }
+                suffix = tmp;
+            } else {
+                suffix = null;
+            }
+            this.checkEntries = pathElements.length - 1 <= 0 ? null : new FsEntry[pathElements.length - 1];
+        }
+
+        boolean matches(FsEntry parent, String childName) {
+            if(checkEntries != null) {
+                Arrays.fill(checkEntries, null);
+            }
+            if(relative) {
+                if(pathElements.length > parent.depth + 1) {
+                    return false;
+                }
+                int i = pathElements.length - 1;
+                if(i > 0) {
+                    FsEntry checkEntry = parent;
+                    do {
+                        if(checkEntry == null) {
+                            return false;
+                        }
+                        checkEntries[i - 1] = checkEntry;
+                        checkEntry = checkEntry.parent;
+                        --i;
+                    } while(i > 0);
+                }
+            } else if(pathElements.length == parent.depth + 1) {
+                if(parent.depth > 0) {
+                    FsEntry checkEntry = parent;
+                    int i = checkEntries.length - 1;
+                    checkEntries[i] = checkEntry;
+                    while(checkEntry.depth > 1) {
+                        checkEntry = checkEntry.parent;
+                        checkEntries[--i] = checkEntry;
+                    }
+                }
+            } else {
+                return false;
+            }
+
+            if(pathElements.length == 0) {
+                return true;
+            }
+            int i = 0;
+            while(i < pathElements.length - 1) {
+                if(!checkEntries[i].name.equals(pathElements[i++])) {
+                    return false;
+                }
+            }
+            if(!childName.endsWith(suffix)) {
+                return false;
+            }
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            final StringBuilder buf = new StringBuilder();
+            if(!relative) {
+                buf.append('/');
+            }
+            if(pathElements.length > 0) {
+                buf.append(pathElements[0]);
+                for(int i = 1; i < pathElements.length; ++i) {
+                    buf.append('/').append(pathElements[i]);
+                }
+            }
+            return buf.toString();
+        }
+    }
+
+    public static FsEntryFactory getInstance() {
+        return new FsEntryFactory();
+    }
+
+    private List<PathFilter> pathFilters = Collections.emptyList();
+
+    private FsEntryFactory() {
+    }
+
+    public FsEntry forPath(Path p) throws ProvisioningException {
+        final FsEntry entry = new FsEntry(null, p);
+        if(entry.dir) {
+            try {
+                initChildren(entry);
+            } catch (IOException e) {
+                throw new ProvisioningException(Errors.fsEntryInit(p), e);
+            }
+        }
+        return entry;
+    }
+
+    private void initChildren(final FsEntry parent) throws IOException {
+        boolean hasDirs = false;
+        try(DirectoryStream<Path> stream = Files.newDirectoryStream(parent.p)) {
+            for(Path c : stream) {
+                if(!pathFilters.isEmpty() && isFiltered(parent, c.getFileName().toString())) {
+                    continue;
+                }
+                hasDirs |= new FsEntry(parent, c).dir;
+            }
+        }
+        if(hasDirs) {
+            for(FsEntry child : parent.getChildren()) {
+                if(!child.dir) {
+                    continue;
+                }
+                initChildren(child);
+            }
+        }
+    }
+
+    private boolean isFiltered(FsEntry parent, String childName) {
+        if(pathFilters.isEmpty()) {
+            return false;
+        }
+        for(PathFilter filter : pathFilters) {
+            if(filter.matches(parent, childName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public FsEntryFactory filter(String pathExpr) {
+        final String[] entries;
+        boolean relative = true;
+        if(pathExpr.isEmpty()) {
+            relative = false;
+            entries = new String[0];
+        } else if(pathExpr.charAt(0) == '/') {
+            relative = false;
+            entries = pathExpr.substring(1).split("/");
+        } else {
+            entries = pathExpr.split("/");
+        }
+        pathFilters = CollectionUtils.add(pathFilters, new PathFilter(entries, relative));
+        return this;
+    }
+}

--- a/core/src/main/java/org/jboss/galleon/layout/ProvisioningLayoutFactory.java
+++ b/core/src/main/java/org/jboss/galleon/layout/ProvisioningLayoutFactory.java
@@ -176,26 +176,11 @@ public class ProvisioningLayoutFactory implements Closeable {
     public ProvisioningLayout<FeaturePackLayout> newConfigLayout(ProvisioningConfig config) throws ProvisioningException {
         return newConfigLayout(config, new FeaturePackLayoutFactory<FeaturePackLayout>() {
             @Override
-            public FeaturePackLayout newFeaturePack(FeaturePackLocation fpl, FeaturePackSpec spec, Path dir, int type) {
-                return new FeaturePackLayout() {
-                    @Override
-                    public FPID getFPID() {
-                        return fpl.getFPID();
-                    }
-
+            public FeaturePackLayout newFeaturePack(FeaturePackLocation fpl, FeaturePackSpec fpSpec, Path dir, int type) {
+                return new FeaturePackLayout(fpl.getFPID(), dir, type) {
                     @Override
                     public FeaturePackSpec getSpec() {
-                        return spec;
-                    }
-
-                    @Override
-                    public Path getDir() {
-                        return dir;
-                    }
-
-                    @Override
-                    public int getType() {
-                        return type;
+                        return fpSpec;
                     }
                 };
             }});

--- a/core/src/main/java/org/jboss/galleon/plugin/NewDiffPlugin.java
+++ b/core/src/main/java/org/jboss/galleon/plugin/NewDiffPlugin.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.galleon.plugin;
+
+import org.jboss.galleon.ProvisioningException;
+import org.jboss.galleon.diff.DiffRuntime;
+
+/**
+ *
+ * @author Alexey Loubyansky
+ */
+public interface NewDiffPlugin extends ProvisioningPlugin {
+
+    void diff(DiffRuntime runtime) throws ProvisioningException;
+}

--- a/core/src/main/java/org/jboss/galleon/runtime/FeaturePackRuntime.java
+++ b/core/src/main/java/org/jboss/galleon/runtime/FeaturePackRuntime.java
@@ -16,7 +16,6 @@
  */
 package org.jboss.galleon.runtime;
 
-import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -26,30 +25,22 @@ import java.util.Set;
 import org.jboss.galleon.ProvisioningDescriptionException;
 import org.jboss.galleon.ProvisioningException;
 import org.jboss.galleon.layout.FeaturePackLayout;
-import org.jboss.galleon.spec.FeaturePackSpec;
 import org.jboss.galleon.spec.FeatureSpec;
 import org.jboss.galleon.state.FeaturePack;
-import org.jboss.galleon.universe.FeaturePackLocation.FPID;
 
 /**
  *
  * @author Alexey Loubyansky
  */
-public class FeaturePackRuntime implements FeaturePack<PackageRuntime>, FeaturePackLayout {
+public class FeaturePackRuntime extends FeaturePackLayout implements FeaturePack<PackageRuntime> {
 
-    private final FPID fpid;
-    private final FeaturePackSpec spec;
-    private final Path dir;
     private final Map<String, PackageRuntime> packages;
     private final Map<String, ResolvedFeatureSpec> featureSpecs;
-    private final int type;
 
     FeaturePackRuntime(FeaturePackRuntimeBuilder builder) throws ProvisioningException {
-        this.fpid = builder.producer.getLocation().getFPID();
-        this.spec = builder.spec;
-        this.dir = builder.dir;
+        super(builder.producer.getLocation().getFPID(), builder.getDir(), builder.getType());
+        this.spec = builder.getSpec();
         this.featureSpecs = builder.featureSpecs;
-        this.type = builder.getType();
 
         Map<String, PackageRuntime> tmpPackages = new LinkedHashMap<>();
         for(String pkgName : builder.pkgOrder) {
@@ -58,26 +49,6 @@ public class FeaturePackRuntime implements FeaturePack<PackageRuntime>, FeatureP
         }
 
         packages = Collections.unmodifiableMap(tmpPackages);
-    }
-
-    @Override
-    public FeaturePackSpec getSpec() {
-        return spec;
-    }
-
-    @Override
-    public int getType() {
-        return type;
-    }
-
-    @Override
-    public Path getDir() {
-        return dir;
-    }
-
-    @Override
-    public FPID getFPID() {
-        return fpid;
     }
 
     @Override

--- a/core/src/main/java/org/jboss/galleon/runtime/FeaturePackRuntimeBuilder.java
+++ b/core/src/main/java/org/jboss/galleon/runtime/FeaturePackRuntimeBuilder.java
@@ -55,12 +55,9 @@ import org.jboss.galleon.xml.XmlParsers;
  *
  * @author Alexey Loubyansky
  */
-public class FeaturePackRuntimeBuilder implements FeaturePackLayout {
+public class FeaturePackRuntimeBuilder extends FeaturePackLayout {
 
     final ProducerSpec producer;
-    final Path dir;
-    private final int type;
-    final FeaturePackSpec spec;
     Map<String, ResolvedFeatureSpec> featureSpecs = null;
     private Map<String, FeatureGroup> fgSpecs = null;
     private Map<ConfigId, ConfigModel> configs = null;
@@ -72,30 +69,10 @@ public class FeaturePackRuntimeBuilder implements FeaturePackLayout {
     private ParameterTypeProvider featureParamTypeProvider = BuiltInParameterTypeProvider.getInstance();
 
     FeaturePackRuntimeBuilder(FPID fpid, FeaturePackSpec spec, Path dir, int type) {
+        super(fpid, dir, type);
         this.producer = fpid.getProducer();
         this.dir = dir;
         this.spec = spec;
-        this.type = type;
-    }
-
-    @Override
-    public FPID getFPID() {
-        return producer.getLocation().getFPID();
-    }
-
-    @Override
-    public FeaturePackSpec getSpec() {
-        return spec;
-    }
-
-    @Override
-    public Path getDir() {
-        return dir;
-    }
-
-    @Override
-    public int getType() {
-        return type;
     }
 
     boolean resolvePackage(String pkgName, ProvisioningRuntimeBuilder rt) throws ProvisioningException {

--- a/core/src/main/java/org/jboss/galleon/runtime/ProvisioningRuntimeBuilder.java
+++ b/core/src/main/java/org/jboss/galleon/runtime/ProvisioningRuntimeBuilder.java
@@ -253,7 +253,7 @@ public class ProvisioningRuntimeBuilder {
 
             boolean extendedStackLevel = false;
             if (!fpConfig.isTransitive()) {
-                final FeaturePackSpec currentSpec = currentOrigin.spec;
+                final FeaturePackSpec currentSpec = currentOrigin.getSpec();
                 if (currentSpec.hasDefinedConfigs()) {
                     for (ConfigModel config : currentSpec.getDefinedConfigs()) {
                         final ConfigId id = config.getId();
@@ -321,7 +321,7 @@ public class ProvisioningRuntimeBuilder {
                     specConfigStacks = CollectionUtils.add(specConfigStacks, configStack);
                 }
 
-                config = currentOrigin.spec.getDefinedConfig(configId);
+                config = currentOrigin.getSpec().getDefinedConfig(configId);
                 if(config != null) {
                     configStack.pushConfig(config);
                     specConfigStacks = CollectionUtils.add(specConfigStacks, configStack);
@@ -331,13 +331,13 @@ public class ProvisioningRuntimeBuilder {
 
             boolean extendedStackLevel = false;
             if (!fpConfig.isTransitive()) {
-                if (currentOrigin.spec.hasFeaturePackDeps()) {
-                    if (currentOrigin.spec.hasTransitiveDeps()) {
-                        for (FeaturePackConfig fpDep : currentOrigin.spec.getTransitiveDeps()) {
+                if (currentOrigin.getSpec().hasFeaturePackDeps()) {
+                    if (currentOrigin.getSpec().hasTransitiveDeps()) {
+                        for (FeaturePackConfig fpDep : currentOrigin.getSpec().getTransitiveDeps()) {
                             extendedStackLevel |= fpConfigStack.push(fpDep, extendedStackLevel);
                         }
                     }
-                    for (FeaturePackConfig fpDep : currentOrigin.spec.getFeaturePackDeps()) {
+                    for (FeaturePackConfig fpDep : currentOrigin.getSpec().getFeaturePackDeps()) {
                         extendedStackLevel |= fpConfigStack.push(fpDep, extendedStackLevel);
                     }
                     if (extendedStackLevel) {
@@ -354,8 +354,8 @@ public class ProvisioningRuntimeBuilder {
                     }
                 }
 
-                if (fpConfig.isInheritPackages() && currentOrigin.spec.hasDefaultPackages()) {
-                    for (String packageName : currentOrigin.spec.getDefaultPackageNames()) {
+                if (fpConfig.isInheritPackages() && currentOrigin.getSpec().hasDefaultPackages()) {
+                    for (String packageName : currentOrigin.getSpec().getDefaultPackageNames()) {
                         if (fpConfigStack.isPackageFilteredOut(currentOrigin.producer, packageName, false)) {
                             continue;
                         }
@@ -446,8 +446,8 @@ public class ProvisioningRuntimeBuilder {
             if (configLayer != null) {
                 layerStack.pushGroup(configLayer);
             }
-            if(fp.spec.hasFeaturePackDeps()) {
-                for(FeaturePackConfig depConfig : fp.spec.getFeaturePackDeps()) {
+            if(fp.getSpec().hasFeaturePackDeps()) {
+                for(FeaturePackConfig depConfig : fp.getSpec().getFeaturePackDeps()) {
                     resolveConfigLayer(layout.getFeaturePack(depConfig.getLocation().getProducer()), layerStack, layerId);
                 }
             }
@@ -509,7 +509,7 @@ public class ProvisioningRuntimeBuilder {
                 modelOnlyStack.pushConfig(config);
                 ++pushedCount;
             }
-            config = fp.spec.getDefinedConfig(configId);
+            config = fp.getSpec().getDefinedConfig(configId);
             if(config != null) {
                 if(modelOnlyStack == null) {
                     modelOnlyStack = new ConfigModelStack(configId, this);
@@ -527,14 +527,14 @@ public class ProvisioningRuntimeBuilder {
             }
 
             boolean extendedStackLevel = false;
-            if (fp.spec.hasTransitiveDeps()) {
-                for (FeaturePackConfig fpDep : fp.spec.getTransitiveDeps()) {
+            if (fp.getSpec().hasTransitiveDeps()) {
+                for (FeaturePackConfig fpDep : fp.getSpec().getTransitiveDeps()) {
                     extendedStackLevel |= fpConfigStack.push(fpDep, extendedStackLevel);
                 }
             }
 
-            if(fp.spec.hasFeaturePackDeps()) {
-                for(FeaturePackConfig fpDep : fp.spec.getFeaturePackDeps()) {
+            if(fp.getSpec().hasFeaturePackDeps()) {
+                for(FeaturePackConfig fpDep : fp.getSpec().getFeaturePackDeps()) {
                     extendedStackLevel |= fpConfigStack.push(fpDep, extendedStackLevel);
                     if(fpDep.isConfigModelExcluded(configId) || !fpDep.isInheritModelOnlyConfigs() && !fpDep.isConfigModelIncluded(configId)) {
                         continue;
@@ -663,7 +663,7 @@ public class ProvisioningRuntimeBuilder {
             }
             return thisOrigin;
         }
-        final FeaturePackLocation fpl = currentOrigin == null ? config.getFeaturePackDep(depName).getLocation() : currentOrigin.spec.getFeaturePackDep(depName).getLocation();
+        final FeaturePackLocation fpl = currentOrigin == null ? config.getFeaturePackDep(depName).getLocation() : currentOrigin.getSpec().getFeaturePackDep(depName).getLocation();
         return layout.getFeaturePack(fpl.getProducer());
     }
 
@@ -909,7 +909,7 @@ public class ProvisioningRuntimeBuilder {
             if(origin.resolvePackage(name, this)) {
                 return true;
             }
-            fpDeps = origin.spec;
+            fpDeps = origin.getSpec();
             visited = CollectionUtils.add(visited, origin.producer);
         } else {
             fpDeps = config;
@@ -1083,7 +1083,7 @@ public class ProvisioningRuntimeBuilder {
                 currentOrigin = origin;
                 return fg;
             }
-            fpDeps = origin.spec;
+            fpDeps = origin.getSpec();
             visitedProducers = CollectionUtils.add(visitedProducers, origin.producer);
         } else {
             fpDeps = config;
@@ -1138,7 +1138,7 @@ public class ProvisioningRuntimeBuilder {
                 }
                 return fs;
             }
-            fpDeps = origin.spec;
+            fpDeps = origin.getSpec();
             visitedProducers = CollectionUtils.add(visitedProducers, origin.producer);
         } else {
             fpDeps = config;

--- a/core/src/main/java/org/jboss/galleon/runtime/ResolvedFeatureSpec.java
+++ b/core/src/main/java/org/jboss/galleon/runtime/ResolvedFeatureSpec.java
@@ -418,7 +418,7 @@ public class ResolvedFeatureSpec extends CapabilityProvider {
             FeatureReferenceSpec refSpec) throws ProvisioningException {
         try {
             if(refSpec.getOrigin() != null) {
-                origin = rt.layout.getFeaturePack(origin.spec.getFeaturePackDep(refSpec.getOrigin()).getLocation().getProducer());
+                origin = rt.layout.getFeaturePack(origin.getSpec().getFeaturePackDep(refSpec.getOrigin()).getLocation().getProducer());
             }
             final ResolvedFeatureSpec resolvedRefSpec = rt.getFeatureSpec(origin, refSpec.getFeature().getName());
             assertRefParamMapping(refSpec, resolvedRefSpec);

--- a/core/src/main/java/org/jboss/galleon/util/LayoutUtils.java
+++ b/core/src/main/java/org/jboss/galleon/util/LayoutUtils.java
@@ -103,4 +103,8 @@ public class LayoutUtils {
         }
         return p;
     }
+
+    public static Path getHashesDir(Path home) {
+        return home.resolve(Constants.PROVISIONED_STATE_DIR).resolve(Constants.HASHES);
+    }
 }

--- a/core/src/test/java/org/jboss/galleon/diff/fs/test/BasicFsEntriesFilteringTestCase.java
+++ b/core/src/test/java/org/jboss/galleon/diff/fs/test/BasicFsEntriesFilteringTestCase.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.galleon.diff.fs.test;
+
+import java.io.IOException;
+import org.jboss.galleon.diff.FsEntry;
+import org.jboss.galleon.diff.FsEntryFactory;
+
+/**
+ *
+ * @author Alexey Loubyansky
+ */
+public class BasicFsEntriesFilteringTestCase extends FsEntriesTestBase {
+
+    @Override
+    protected void initFs() throws IOException {
+        createFile("a/b/file1.txt", "file1");
+        createFile("a/b/file2.txt", "file1");
+        mkdir("a/b/f");
+        createFile("a/b/c/file1.txt", "file1");
+        createFile("a/d/file1.txt", "file1");
+        createFile("e/file1.txt", "file1");
+        createFile("file1.txt", "file1");
+        mkdir("g");
+    }
+
+    @Override
+    protected void initFactory(FsEntryFactory factory) {
+        factory.filter("/a/b/c");
+        factory.filter("/a/b/file1.txt");
+    }
+
+    @Override
+    protected void assertRootEntry(FsEntry rootEntry) throws Exception {
+        final FsEntry expectedRoot = new FsEntry(null, root);
+        final FsEntry a = new FsEntry(expectedRoot, root.resolve("a"));
+        final FsEntry b = new FsEntry(a, root.resolve("a/b"));
+        new FsEntry(b, root.resolve("a/b/file2.txt"));
+        new FsEntry(b, root.resolve("a/b/f"));
+        final FsEntry d = new FsEntry(a, root.resolve("a/d"));
+        new FsEntry(d, root.resolve("a/d/file1.txt"));
+        final FsEntry e = new FsEntry(expectedRoot, root.resolve("e"));
+        new FsEntry(e, root.resolve("e/file1.txt"));
+        new FsEntry(expectedRoot, root.resolve("file1.txt"));
+        new FsEntry(expectedRoot, root.resolve("g"));
+
+        assertIdentical(expectedRoot, rootEntry);
+    }
+}

--- a/core/src/test/java/org/jboss/galleon/diff/fs/test/BasicFsEntriesTestCase.java
+++ b/core/src/test/java/org/jboss/galleon/diff/fs/test/BasicFsEntriesTestCase.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.galleon.diff.fs.test;
+
+import java.io.IOException;
+import org.jboss.galleon.diff.FsEntry;
+
+/**
+ *
+ * @author Alexey Loubyansky
+ */
+public class BasicFsEntriesTestCase extends FsEntriesTestBase {
+
+    @Override
+    protected void initFs() throws IOException {
+        createFile("a/b/file1.txt", "file1");
+        createFile("a/b/file2.txt", "file1");
+        mkdir("a/b/f");
+        createFile("a/b/c/file1.txt", "file1");
+        createFile("a/d/file1.txt", "file1");
+        createFile("e/file1.txt", "file1");
+        createFile("file1.txt", "file1");
+        mkdir("g");
+    }
+
+    @Override
+    protected void assertRootEntry(FsEntry rootEntry) throws Exception {
+        final FsEntry expectedRoot = new FsEntry(null, root);
+        final FsEntry a = new FsEntry(expectedRoot, root.resolve("a"));
+        final FsEntry b = new FsEntry(a, root.resolve("a/b"));
+        new FsEntry(b, root.resolve("a/b/file1.txt"));
+        new FsEntry(b, root.resolve("a/b/file2.txt"));
+        new FsEntry(b, root.resolve("a/b/f"));
+        final FsEntry c = new FsEntry(b, root.resolve("a/b/c"));
+        new FsEntry(c, root.resolve("a/b/c/file1.txt"));
+        final FsEntry d = new FsEntry(a, root.resolve("a/d"));
+        new FsEntry(d, root.resolve("a/d/file1.txt"));
+        final FsEntry e = new FsEntry(expectedRoot, root.resolve("e"));
+        new FsEntry(e, root.resolve("e/file1.txt"));
+        new FsEntry(expectedRoot, root.resolve("file1.txt"));
+        new FsEntry(expectedRoot, root.resolve("g"));
+
+        assertIdentical(expectedRoot, rootEntry);
+    }
+}

--- a/core/src/test/java/org/jboss/galleon/diff/fs/test/BasicWildcardFilteringTestCase.java
+++ b/core/src/test/java/org/jboss/galleon/diff/fs/test/BasicWildcardFilteringTestCase.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.galleon.diff.fs.test;
+
+import java.io.IOException;
+import org.jboss.galleon.diff.FsEntry;
+import org.jboss.galleon.diff.FsEntryFactory;
+
+/**
+ *
+ * @author Alexey Loubyansky
+ */
+public class BasicWildcardFilteringTestCase extends FsEntriesTestBase {
+
+    @Override
+    protected void initFs() throws IOException {
+        createFile("a/b/file1.glnew", "file1");
+        createFile("a/b/file2.txt", "file1");
+        mkdir("a/b/f");
+        createFile("a/b/c/file1.txt", "file1");
+        createFile("a/d/file1.glnew", "file1");
+        createFile("e/file1.txt", "file1");
+        createFile("file1.glnew", "file1");
+        mkdir("g");
+    }
+
+    @Override
+    protected void initFactory(FsEntryFactory factory) {
+        factory.filter("*.glnew");
+        factory.filter("*e");
+    }
+
+    @Override
+    protected void assertRootEntry(FsEntry rootEntry) throws Exception {
+        final FsEntry expectedRoot = new FsEntry(null, root);
+        final FsEntry a = new FsEntry(expectedRoot, root.resolve("a"));
+        final FsEntry b = new FsEntry(a, root.resolve("a/b"));
+        new FsEntry(b, root.resolve("a/b/file2.txt"));
+        new FsEntry(b, root.resolve("a/b/c"));
+        new FsEntry(b, root.resolve("a/b/f"));
+        new FsEntry(a, root.resolve("a/d"));
+        new FsEntry(expectedRoot, root.resolve("g"));
+
+        assertIdentical(expectedRoot, rootEntry);
+    }
+}

--- a/core/src/test/java/org/jboss/galleon/diff/fs/test/FsEntriesTestBase.java
+++ b/core/src/test/java/org/jboss/galleon/diff/fs/test/FsEntriesTestBase.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.galleon.diff.fs.test;
+
+import static org.junit.Assert.fail;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.jboss.galleon.ProvisioningException;
+import org.jboss.galleon.diff.FsDiff;
+import org.jboss.galleon.diff.FsEntry;
+import org.jboss.galleon.diff.FsEntryFactory;
+import org.jboss.galleon.util.IoUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ *
+ * @author Alexey Loubyansky
+ */
+public abstract class FsEntriesTestBase {
+
+    protected Path root;
+
+    @Before
+    public void init() throws Exception {
+        root = IoUtils.createRandomTmpDir();
+    }
+
+    @After
+    public void cleanup() throws Exception {
+        IoUtils.recursiveDelete(root);
+    }
+
+    protected void createFile(String relativePath, String content) throws IOException {
+        if(relativePath.charAt(0) == '/') {
+            relativePath = relativePath.substring(1);
+        }
+        final Path target = root.resolve(relativePath);
+        Files.createDirectories(target.getParent());
+        try(BufferedWriter writer = Files.newBufferedWriter(target)) {
+            writer.write(content);
+        }
+    }
+
+    protected void mkdir(String relativePath) throws IOException {
+        if(relativePath.charAt(0) == '/') {
+            relativePath = relativePath.substring(1);
+        }
+        final Path target = root.resolve(relativePath);
+        Files.createDirectories(target);
+    }
+
+    protected void initFs() throws IOException {
+    }
+
+    protected void initFactory(FsEntryFactory factory) {
+    }
+
+    protected abstract void assertRootEntry(FsEntry rootEntry) throws Exception;
+
+    @Test
+    public void test() throws Exception {
+        initFs();
+        final FsEntryFactory factory = FsEntryFactory.getInstance();
+        initFactory(factory);
+        assertRootEntry(factory.forPath(root));
+    }
+
+    protected void assertIdentical(FsEntry expected, FsEntry actual) throws ProvisioningException {
+        final FsDiff diff = FsDiff.diff(expected, actual);
+        if(diff.isEmpty()) {
+            return;
+        }
+        fail(diff.toString());
+    }
+}

--- a/docs/guide/index.adoc
+++ b/docs/guide/index.adoc
@@ -36,6 +36,8 @@ include::provisioned-config/index.adoc[]
 
 include::patches/index.adoc[]
 
+include::user-managed-content/index.adoc[]
+
 include::maven-plugin/index.adoc[]
 
 include::tool/index.adoc[]

--- a/docs/guide/user-managed-content/index.adoc
+++ b/docs/guide/user-managed-content/index.adoc
@@ -1,0 +1,86 @@
+## Handling user-managed content
+
+Once an installation has been built, a user or a process (on behalf of the user) may apply certain changes to the content of the installation such as add, edit or remove files and/or directories.
+
+CAUTION: Since these kind of changes are not performed by the provisioning mechanism, it is the responsibility of the user to apply them in a safe manner and not break the installation by introducing some sort of unsatisfied dependencies or violating integrity constraints.
+
+Since these kind of changes are usually going to be applied after the installation has been built they don't interfere with the provisioning process. That is until the next (provisioning state) update.
+
+When a user requests a version update or install/uninstall a patch or a feature-pack, or an undo for the installation that contains user-managed content or changes, the provisioning mechanism detects what exactly has changed since the last provisioned state.
+
+If no user changes have been detected, the updated version of the installation will replace the current one. However, if the provisioning mechanism did detect certain changes to the last provisioned state (in the form of added/remove files and/or directories or editted files), those changes will be respected and re-applied to the updated installation state, i.e.
+
+- files and/or directories added to the previous installation state will be added to the updated installation state;
+
+- files and/or directories removed from the previous installation state will be removed from the updated installation state;
+
+- files editted in the previous installation state will be copied over to the updated installation state.
+
+IMPORTANT: The provisioning mechanism *DOES NOT* perform 3-way merges on files that have changed in the updated installation state since the last provisioned state and that have also been modified by the user.
+
+### Application of user changes to the updated installation state
+
+.User-added file
+[%header,cols="1,1a"]
+|===
+|Target in the updated state |Change applied to the updated state
+
+|Not found
+|The user-added file is copied to the updated state
+
+|Found and matches the file added by the user
+|
+None
+
+|Found and is different from the file added by the user
+|
+* A copy of the file from the updated state is created with suffix *.glnew*
+
+* The user-added file is copied to the updated state (replacing the existing one)
+|===
+
+.User-modified file
+[%header,cols="1,1a"]
+|===
+|Target in the updated state |Change applied to the updated state
+
+|Not found
+|The user-modified file is copied to the updated state and a warning is logged saying that the (equivalent of the) file modified in the previous state is not found in the updated state
+
+|Found and matches the resulting file modified by the user
+|
+None
+
+|Found and is different from the resulting file modified by the user
+|
+* A copy of the file from the updated state is created with suffix *.glnew*
+
+* The user-modified file is copied to the updated state (replacing the existing one)
+|===
+
+.User-removed file or directory
+[%header,cols="1,1a"]
+|===
+|Target in the updated state |Change applied to the updated state
+
+|Not found
+|None
+
+|Found
+|The target is removed from the updated installation
+
+|===
+
+.User-created directory
+[%header,cols="1,1a"]
+|===
+|Target in the updated state |Change applied to the updated state
+
+|Not found
+|The corresponding directory is created in the updated state
+
+|Found
+|None
+
+|===
+

--- a/testsuite/src/test/java/org/jboss/galleon/userchanges/test/UndoUpdateWithMatchingUserRemovedFileTestCase.java
+++ b/testsuite/src/test/java/org/jboss/galleon/userchanges/test/UndoUpdateWithMatchingUserRemovedFileTestCase.java
@@ -14,12 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.galleon.undo.test;
 
-import java.io.File;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import org.jboss.galleon.Constants;
+package org.jboss.galleon.userchanges.test;
+
 import org.jboss.galleon.ProvisioningDescriptionException;
 import org.jboss.galleon.ProvisioningException;
 import org.jboss.galleon.ProvisioningManager;
@@ -31,21 +28,17 @@ import org.jboss.galleon.state.ProvisionedState;
 import org.jboss.galleon.test.util.fs.state.DirState;
 import org.jboss.galleon.universe.FeaturePackLocation;
 import org.jboss.galleon.universe.MvnUniverse;
-import org.jboss.galleon.universe.SingleUniverseTestBase;
-import org.jboss.galleon.util.PathsUtils;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import org.junit.Ignore;
 
 /**
  *
- * @author jdenise@redhat.com
+ * @author Alexey Loubyansky
  */
-public class ClearStateHistoryTestCase extends SingleUniverseTestBase {
+@Ignore
+public class UndoUpdateWithMatchingUserRemovedFileTestCase extends UserChangesTestBase {
 
-    private FeaturePackLocation fp100;
-    private FeaturePackLocation fp101;
+    private FeaturePackLocation prod100;
+    private FeaturePackLocation prod101;
 
     @Override
     protected void createProducers(MvnUniverse universe) throws ProvisioningException {
@@ -54,58 +47,49 @@ public class ClearStateHistoryTestCase extends SingleUniverseTestBase {
 
     @Override
     protected void createFeaturePacks(FeaturePackCreator creator) throws ProvisioningException {
-        fp100 = newFpl("prod1", "1", "1.0.0.Final");
-        creator.newFeaturePack(fp100.getFPID())
-                .newPackage("p1", true)
-                .writeContent("fp1/p1.txt", "fp100 p1");
+        prod100 = newFpl("prod1", "1", "1.0.0.Final");
+        creator.newFeaturePack(prod100.getFPID())
+            .newPackage("p1", true)
+                .writeContent("prod1/p1.txt", "prod1 p1")
+                .writeContent("prod1/p2.txt", "prod1 p2");
 
-        fp101 = newFpl("prod1", "1", "1.0.1.Final");
-        creator.newFeaturePack(fp101.getFPID())
-                .newPackage("p1", true)
-                .writeContent("fp1/p1.txt", "fp101 p1");
+        prod101 = newFpl("prod1", "1", "1.0.1.Final");
+        creator.newFeaturePack(prod101.getFPID())
+            .newPackage("p1", true)
+                .writeContent("prod1/p1.txt", "prod1 p1");
 
         creator.install();
     }
 
     @Override
-    protected ProvisioningConfig initialState() throws ProvisioningException {
-        return ProvisioningConfig.builder()
-                .addFeaturePackDep(fp100)
-                .build();
+    protected void testPm(ProvisioningManager pm) throws ProvisioningException {
+        pm.install(prod100);
+        recursiveDelete("prod1/p2.txt");
+        pm.install(prod101);
+        pm.undo();
     }
 
-    @Override
-    protected void testPm(ProvisioningManager pm) throws ProvisioningException {
-        pm.install(fp101);
-        assertTrue(pm.isUndoAvailable());
-        pm.clearStateHistory();
-        assertFalse(pm.isUndoAvailable());
-        Path installedHistoryDir = PathsUtils.getStateHistoryDir(installHome);
-        assertTrue(Files.exists(installedHistoryDir));
-        File[] files = installedHistoryDir.toFile().listFiles();
-        assertEquals(1, files.length);
-        assertTrue(files[0].getName().equals(Constants.HISTORY_LIST));
-    }
 
     @Override
     protected ProvisioningConfig provisionedConfig() throws ProvisioningDescriptionException {
         return ProvisioningConfig.builder()
-                .addFeaturePackDep(FeaturePackConfig.builder(fp101)
-                        .build()).build();
+                .addFeaturePackDep(FeaturePackConfig.builder(prod100).build())
+                .build();
     }
 
     @Override
     protected ProvisionedState provisionedState() throws ProvisioningException {
         return ProvisionedState.builder()
-                .addFeaturePack(ProvisionedFeaturePack.builder(fp101.getFPID())
+                .addFeaturePack(ProvisionedFeaturePack.builder(prod100.getFPID())
                         .addPackage("p1")
-                        .build()).build();
+                        .build())
+                .build();
     }
 
     @Override
     protected DirState provisionedHomeDir() {
         return newDirBuilder()
-                .addFile("fp1/p1.txt", "fp101 p1")
+                .addFile("prod1/p1.txt", "prod1 p1")
                 .build();
     }
 }

--- a/testsuite/src/test/java/org/jboss/galleon/userchanges/test/UserChangesAfterInstallTestCase.java
+++ b/testsuite/src/test/java/org/jboss/galleon/userchanges/test/UserChangesAfterInstallTestCase.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.galleon.userchanges.test;
+
+import org.jboss.galleon.ProvisioningDescriptionException;
+import org.jboss.galleon.ProvisioningException;
+import org.jboss.galleon.ProvisioningManager;
+import org.jboss.galleon.config.FeaturePackConfig;
+import org.jboss.galleon.config.ProvisioningConfig;
+import org.jboss.galleon.creator.FeaturePackCreator;
+import org.jboss.galleon.state.ProvisionedFeaturePack;
+import org.jboss.galleon.state.ProvisionedState;
+import org.jboss.galleon.test.util.fs.state.DirState;
+import org.jboss.galleon.universe.FeaturePackLocation;
+import org.jboss.galleon.universe.MvnUniverse;
+
+/**
+ *
+ * @author Alexey Loubyansky
+ */
+public class UserChangesAfterInstallTestCase extends UserChangesTestBase {
+
+    private FeaturePackLocation prod1;
+    private FeaturePackLocation prod2;
+
+    @Override
+    protected void createProducers(MvnUniverse universe) throws ProvisioningException {
+        universe.createProducer("prod1");
+        universe.createProducer("prod2");
+    }
+
+    @Override
+    protected void createFeaturePacks(FeaturePackCreator creator) throws ProvisioningException {
+        prod1 = newFpl("prod1", "1", "1.0.0.Final");
+        creator.newFeaturePack(prod1.getFPID())
+            .newPackage("p1", true)
+                .addDependency("p2")
+                .addDependency("p3")
+                .writeContent("prod1/p1.txt", "prod1 p1")
+                .getFeaturePack()
+            .newPackage("p2")
+                .writeContent("prod1/p2.txt", "prod1 p2")
+                .getFeaturePack()
+            .newPackage("p3")
+                .writeContent("prod1/p3.txt", "prod1 p3")
+                .getFeaturePack()
+            .newPackage("common", true)
+                .writeContent("common.txt", "prod1");
+
+        prod2 = newFpl("prod2", "1", "1.0.0.Final");
+        creator.newFeaturePack(prod2.getFPID())
+            .newPackage("p1", true)
+                .writeContent("prod2/p1.txt", "prod2 p1")
+                .getFeaturePack()
+            .newPackage("p2", true)
+                .writeContent("prod2/p2.txt", "prod2 p2")
+                .getFeaturePack()
+            .newPackage("p3", true)
+                .writeContent("prod2/p3.txt", "prod2 p3")
+                .getFeaturePack()
+            .newPackage("common", true)
+                .writeContent("common.txt", "prod2");
+
+        creator.install();
+    }
+
+    @Override
+    protected void testPm(ProvisioningManager pm) throws ProvisioningException {
+        pm.install(prod1);
+        writeContent("new.txt", "user");
+        writeContent("prod1/p2.txt", "user");
+        recursiveDelete("prod1/p3.txt");
+        mkdirs("prod1/user");
+        writeContent("prod2/p2.txt", "prod2 p2");
+        writeContent("prod2/p3.txt", "user");
+        writeContent("common.txt", "user");
+        pm.install(prod2);
+    }
+
+
+    @Override
+    protected ProvisioningConfig provisionedConfig() throws ProvisioningDescriptionException {
+        return ProvisioningConfig.builder()
+                .addFeaturePackDep(FeaturePackConfig.builder(prod1)
+                        .build())
+                .addFeaturePackDep(FeaturePackConfig.builder(prod2)
+                        .build())
+                .build();
+    }
+
+    @Override
+    protected ProvisionedState provisionedState() throws ProvisioningException {
+        return ProvisionedState.builder()
+                .addFeaturePack(ProvisionedFeaturePack.builder(prod1.getFPID())
+                        .addPackage("p1")
+                        .addPackage("p2")
+                        .addPackage("p3")
+                        .addPackage("common")
+                        .build())
+                .addFeaturePack(ProvisionedFeaturePack.builder(prod2.getFPID())
+                        .addPackage("p1")
+                        .addPackage("p2")
+                        .addPackage("p3")
+                        .addPackage("common")
+                        .build())
+                .build();
+    }
+
+    @Override
+    protected DirState provisionedHomeDir() {
+        return newDirBuilder()
+                .addFile("prod1/p1.txt", "prod1 p1")
+                .addFile("prod1/p2.txt", "user")
+                .addFile("prod1/p2.txt.glnew", "prod1 p2")
+                .addDir("prod1/user")
+                .addFile("prod2/p1.txt", "prod2 p1")
+                .addFile("prod2/p2.txt", "prod2 p2")
+                .addFile("prod2/p3.txt", "user")
+                .addFile("prod2/p3.txt.glnew", "prod2 p3")
+                .addFile("new.txt", "user")
+                .addFile("common.txt", "user")
+                .addFile("common.txt.glnew", "prod2")
+                .build();
+    }
+}

--- a/testsuite/src/test/java/org/jboss/galleon/userchanges/test/UserChangesAfterMultipleUpdatesTestCase.java
+++ b/testsuite/src/test/java/org/jboss/galleon/userchanges/test/UserChangesAfterMultipleUpdatesTestCase.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.galleon.userchanges.test;
+
+import org.jboss.galleon.ProvisioningDescriptionException;
+import org.jboss.galleon.ProvisioningException;
+import org.jboss.galleon.ProvisioningManager;
+import org.jboss.galleon.config.FeaturePackConfig;
+import org.jboss.galleon.config.ProvisioningConfig;
+import org.jboss.galleon.creator.FeaturePackCreator;
+import org.jboss.galleon.state.ProvisionedFeaturePack;
+import org.jboss.galleon.state.ProvisionedState;
+import org.jboss.galleon.test.util.fs.state.DirState;
+import org.jboss.galleon.universe.FeaturePackLocation;
+import org.jboss.galleon.universe.MvnUniverse;
+
+/**
+ *
+ * @author Alexey Loubyansky
+ */
+public class UserChangesAfterMultipleUpdatesTestCase extends UserChangesTestBase {
+
+    private FeaturePackLocation prod100;
+    private FeaturePackLocation prod101;
+    private FeaturePackLocation prod200;
+
+    @Override
+    protected void createProducers(MvnUniverse universe) throws ProvisioningException {
+        universe.createProducer("prod1");
+        universe.createProducer("prod2");
+    }
+
+    @Override
+    protected void createFeaturePacks(FeaturePackCreator creator) throws ProvisioningException {
+        prod100 = newFpl("prod1", "1", "1.0.0.Final");
+        creator.newFeaturePack(prod100.getFPID())
+            .newPackage("p1", true)
+                .addDependency("p2")
+                .addDependency("p3")
+                .writeContent("prod1/p1.txt", "prod100 p1")
+                .getFeaturePack()
+            .newPackage("p2")
+                .writeContent("prod1/p2.txt", "prod100 p2")
+                .getFeaturePack()
+            .newPackage("p3")
+                .writeContent("prod1/p3.txt", "prod100 p3")
+                .getFeaturePack()
+            .newPackage("p4", true)
+                .writeContent("prod1/p4.txt", "prod100 p4")
+                .getFeaturePack()
+            .newPackage("common", true)
+                .writeContent("common.txt", "prod100");
+
+        prod101 = newFpl("prod1", "1", "1.0.1.Final");
+        creator.newFeaturePack(prod101.getFPID())
+            .newPackage("p1", true)
+                .addDependency("p2")
+                .addDependency("p3")
+                .writeContent("prod1/p101.txt", "prod101 p1")
+                .getFeaturePack()
+            .newPackage("p2")
+                .writeContent("prod1/p2.txt", "prod101 p2")
+                .getFeaturePack()
+            .newPackage("p3")
+                .writeContent("prod1/p3.txt", "prod101 p3")
+                .getFeaturePack()
+            .newPackage("p4", true)
+                .writeContent("prod1/p4.txt", "prod101 p4")
+                .getFeaturePack()
+            .newPackage("common", true)
+                .writeContent("common.txt", "prod101");
+
+        prod200 = newFpl("prod2", "1", "1.0.0.Final");
+        creator.newFeaturePack(prod200.getFPID())
+            .newPackage("p1", true)
+                .writeContent("prod2/p1.txt", "prod200 p1");
+
+        creator.install();
+    }
+
+    @Override
+    protected void testPm(ProvisioningManager pm) throws ProvisioningException {
+        pm.install(prod100);
+        writeContent("prod1/p1.txt", "user");
+        writeContent("prod1/p2.txt", "user");
+        writeContent("prod1/p3.txt", "user");
+        pm.install(prod101);
+        writeContent("prod1/p3.txt", "user2");
+        pm.install(prod200);
+    }
+
+
+    @Override
+    protected ProvisioningConfig provisionedConfig() throws ProvisioningDescriptionException {
+        return ProvisioningConfig.builder()
+                .addFeaturePackDep(FeaturePackConfig.builder(prod101).build())
+                .addFeaturePackDep(FeaturePackConfig.builder(prod200).build())
+                .build();
+    }
+
+    @Override
+    protected ProvisionedState provisionedState() throws ProvisioningException {
+        return ProvisionedState.builder()
+                .addFeaturePack(ProvisionedFeaturePack.builder(prod101.getFPID())
+                        .addPackage("p1")
+                        .addPackage("p2")
+                        .addPackage("p3")
+                        .addPackage("p4")
+                        .addPackage("common")
+                        .build())
+                .addFeaturePack(ProvisionedFeaturePack.builder(prod200.getFPID())
+                        .addPackage("p1")
+                        .build())
+                .build();
+    }
+
+    @Override
+    protected DirState provisionedHomeDir() {
+        return newDirBuilder()
+                .addFile("prod1/p1.txt", "user")
+                .addFile("prod1/p2.txt", "user")
+                .addFile("prod1/p2.txt.glnew", "prod101 p2")
+                .addFile("prod1/p3.txt", "user2")
+                .addFile("prod1/p3.txt.glnew", "prod101 p3")
+                .addFile("prod1/p4.txt", "prod101 p4")
+                .addFile("prod1/p101.txt", "prod101 p1")
+                .addFile("prod2/p1.txt", "prod200 p1")
+                .addFile("common.txt", "prod101")
+                .build();
+    }
+}

--- a/testsuite/src/test/java/org/jboss/galleon/userchanges/test/UserChangesAfterProvisioningConfigTestCase.java
+++ b/testsuite/src/test/java/org/jboss/galleon/userchanges/test/UserChangesAfterProvisioningConfigTestCase.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.galleon.userchanges.test;
+
+import org.jboss.galleon.ProvisioningDescriptionException;
+import org.jboss.galleon.ProvisioningException;
+import org.jboss.galleon.ProvisioningManager;
+import org.jboss.galleon.config.FeaturePackConfig;
+import org.jboss.galleon.config.ProvisioningConfig;
+import org.jboss.galleon.creator.FeaturePackCreator;
+import org.jboss.galleon.state.ProvisionedFeaturePack;
+import org.jboss.galleon.state.ProvisionedState;
+import org.jboss.galleon.test.util.fs.state.DirState;
+import org.jboss.galleon.universe.FeaturePackLocation;
+import org.jboss.galleon.universe.MvnUniverse;
+
+/**
+ *
+ * @author Alexey Loubyansky
+ */
+public class UserChangesAfterProvisioningConfigTestCase extends UserChangesTestBase {
+
+    private FeaturePackLocation prod100;
+    private FeaturePackLocation prod101;
+    private FeaturePackLocation prod200;
+
+    @Override
+    protected void createProducers(MvnUniverse universe) throws ProvisioningException {
+        universe.createProducer("prod1");
+        universe.createProducer("prod2");
+    }
+
+    @Override
+    protected void createFeaturePacks(FeaturePackCreator creator) throws ProvisioningException {
+        prod100 = newFpl("prod1", "1", "1.0.0.Final");
+        creator.newFeaturePack(prod100.getFPID())
+            .newPackage("p1", true)
+                .addDependency("p2")
+                .addDependency("p3")
+                .writeContent("prod1/p1.txt", "prod1 p1")
+                .getFeaturePack()
+            .newPackage("p2")
+                .writeContent("prod1/p2.txt", "prod1 p2")
+                .getFeaturePack()
+            .newPackage("p3")
+                .writeContent("prod1/p3.txt", "prod1 p3");
+
+        prod101 = newFpl("prod1", "1", "1.0.1.Final");
+        creator.newFeaturePack(prod101.getFPID())
+            .newPackage("p1", true)
+                .addDependency("p2")
+                .addDependency("p3")
+                .writeContent("prod1/p1.txt", "prod101 p1")
+                .getFeaturePack()
+            .newPackage("p2")
+                .writeContent("prod1/p2.txt", "prod101 p2")
+                .getFeaturePack()
+            .newPackage("p3")
+                .writeContent("prod1/p3.txt", "prod101 p3");
+
+        prod200 = newFpl("prod2", "1", "1.0.0.Final");
+        creator.newFeaturePack(prod200.getFPID())
+            .newPackage("p1", true)
+                .writeContent("prod2/p1.txt", "prod2 p1");
+
+        creator.install();
+    }
+
+    @Override
+    protected void testPm(ProvisioningManager pm) throws ProvisioningException {
+        pm.install(prod100);
+        writeContent("new.txt", "user");
+        writeContent("prod1/p2.txt", "user");
+        recursiveDelete("prod1/p3.txt");
+        mkdirs("prod1/user");
+
+        pm.provision(ProvisioningConfig.builder()
+                .addFeaturePackDep(prod101)
+                .addFeaturePackDep(prod200)
+                .build());
+    }
+
+
+    @Override
+    protected ProvisioningConfig provisionedConfig() throws ProvisioningDescriptionException {
+        return ProvisioningConfig.builder()
+                .addFeaturePackDep(FeaturePackConfig.builder(prod101)
+                        .build())
+                .addFeaturePackDep(FeaturePackConfig.builder(prod200)
+                        .build())
+                .build();
+    }
+
+    @Override
+    protected ProvisionedState provisionedState() throws ProvisioningException {
+        return ProvisionedState.builder()
+                .addFeaturePack(ProvisionedFeaturePack.builder(prod101.getFPID())
+                        .addPackage("p1")
+                        .addPackage("p2")
+                        .addPackage("p3")
+                        .build())
+                .addFeaturePack(ProvisionedFeaturePack.builder(prod200.getFPID())
+                        .addPackage("p1")
+                        .build())
+                .build();
+    }
+
+    @Override
+    protected DirState provisionedHomeDir() {
+        return newDirBuilder()
+                .addFile("prod1/p1.txt", "prod101 p1")
+                .addFile("prod1/p2.txt", "user")
+                .addFile("prod1/p2.txt.glnew", "prod101 p2")
+                .addFile("prod2/p1.txt", "prod2 p1")
+                .addFile("new.txt", "user")
+                .addDir("prod1/user")
+                .build();
+    }
+}

--- a/testsuite/src/test/java/org/jboss/galleon/userchanges/test/UserChangesAfterUndoAndUninstallAllTheWayTestCase.java
+++ b/testsuite/src/test/java/org/jboss/galleon/userchanges/test/UserChangesAfterUndoAndUninstallAllTheWayTestCase.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.galleon.userchanges.test;
+
+import org.jboss.galleon.ProvisioningDescriptionException;
+import org.jboss.galleon.ProvisioningException;
+import org.jboss.galleon.ProvisioningManager;
+import org.jboss.galleon.config.ProvisioningConfig;
+import org.jboss.galleon.creator.FeaturePackCreator;
+import org.jboss.galleon.state.ProvisionedState;
+import org.jboss.galleon.test.util.fs.state.DirState;
+import org.jboss.galleon.universe.FeaturePackLocation;
+import org.jboss.galleon.universe.MvnUniverse;
+
+/**
+ *
+ * @author Alexey Loubyansky
+ */
+public class UserChangesAfterUndoAndUninstallAllTheWayTestCase extends UserChangesTestBase {
+
+    private FeaturePackLocation prod100;
+    private FeaturePackLocation prod101;
+    private FeaturePackLocation prod200;
+
+    @Override
+    protected void createProducers(MvnUniverse universe) throws ProvisioningException {
+        universe.createProducer("prod1");
+        universe.createProducer("prod2");
+    }
+
+    @Override
+    protected void createFeaturePacks(FeaturePackCreator creator) throws ProvisioningException {
+        prod100 = newFpl("prod1", "1", "1.0.0.Final");
+        creator.newFeaturePack(prod100.getFPID())
+            .newPackage("p1", true)
+                .addDependency("p2")
+                .addDependency("p3")
+                .writeContent("prod1/p1.txt", "prod100 p1")
+                .getFeaturePack()
+            .newPackage("p2")
+                .writeContent("prod1/p2.txt", "prod100 p2")
+                .getFeaturePack()
+            .newPackage("p3")
+                .writeContent("prod1/p3.txt", "prod100 p3")
+                .getFeaturePack()
+            .newPackage("p4", true)
+                .writeContent("prod1/p4.txt", "prod100 p4")
+                .getFeaturePack()
+            .newPackage("common", true)
+                .writeContent("common.txt", "prod100");
+
+        prod101 = newFpl("prod1", "1", "1.0.1.Final");
+        creator.newFeaturePack(prod101.getFPID())
+            .newPackage("p1", true)
+                .addDependency("p2")
+                .addDependency("p3")
+                .writeContent("prod1/p101.txt", "prod101 p1")
+                .getFeaturePack()
+            .newPackage("p2")
+                .writeContent("prod1/p2.txt", "prod101 p2")
+                .getFeaturePack()
+            .newPackage("p3")
+                .writeContent("prod1/p3.txt", "prod101 p3")
+                .getFeaturePack()
+            .newPackage("p4", true)
+                .writeContent("prod1/p4.txt", "prod101 p4")
+                .getFeaturePack()
+            .newPackage("common", true)
+                .writeContent("common.txt", "prod101");
+
+        prod200 = newFpl("prod2", "1", "1.0.0.Final");
+        creator.newFeaturePack(prod200.getFPID())
+            .newPackage("p1", true)
+                .writeContent("prod2/p1.txt", "prod200 p1");
+
+        creator.install();
+    }
+
+    @Override
+    protected void testPm(ProvisioningManager pm) throws ProvisioningException {
+        pm.install(prod100);
+        writeContent("prod1/p1.txt", "user");
+        writeContent("prod1/p2.txt", "user");
+        writeContent("prod1/p3.txt", "user");
+        pm.install(prod101);
+        writeContent("prod1/p3.txt", "user2");
+        pm.install(prod200);
+        while(pm.isUndoAvailable()) {
+            pm.undo();
+        }
+        pm.uninstall(prod100.getFPID());
+    }
+
+
+    @Override
+    protected ProvisioningConfig provisionedConfig() throws ProvisioningDescriptionException {
+        return ProvisioningConfig.builder().build();
+    }
+
+    @Override
+    protected ProvisionedState provisionedState() throws ProvisioningException {
+        return ProvisionedState.builder().build();
+    }
+
+    @Override
+    protected DirState provisionedHomeDir() {
+        return newDirBuilder()
+                .addFile("prod1/p1.txt", "user")
+                .addFile("prod1/p2.txt", "user")
+                .addFile("prod1/p3.txt", "user2")
+                .build();
+    }
+}

--- a/testsuite/src/test/java/org/jboss/galleon/userchanges/test/UserChangesAfterUndoMultipleUpdatesTestCase.java
+++ b/testsuite/src/test/java/org/jboss/galleon/userchanges/test/UserChangesAfterUndoMultipleUpdatesTestCase.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.galleon.userchanges.test;
+
+import org.jboss.galleon.ProvisioningDescriptionException;
+import org.jboss.galleon.ProvisioningException;
+import org.jboss.galleon.ProvisioningManager;
+import org.jboss.galleon.config.FeaturePackConfig;
+import org.jboss.galleon.config.ProvisioningConfig;
+import org.jboss.galleon.creator.FeaturePackCreator;
+import org.jboss.galleon.state.ProvisionedFeaturePack;
+import org.jboss.galleon.state.ProvisionedState;
+import org.jboss.galleon.test.util.fs.state.DirState;
+import org.jboss.galleon.universe.FeaturePackLocation;
+import org.jboss.galleon.universe.MvnUniverse;
+
+/**
+ *
+ * @author Alexey Loubyansky
+ */
+public class UserChangesAfterUndoMultipleUpdatesTestCase extends UserChangesTestBase {
+
+    private FeaturePackLocation prod100;
+    private FeaturePackLocation prod101;
+    private FeaturePackLocation prod200;
+
+    @Override
+    protected void createProducers(MvnUniverse universe) throws ProvisioningException {
+        universe.createProducer("prod1");
+        universe.createProducer("prod2");
+    }
+
+    @Override
+    protected void createFeaturePacks(FeaturePackCreator creator) throws ProvisioningException {
+        prod100 = newFpl("prod1", "1", "1.0.0.Final");
+        creator.newFeaturePack(prod100.getFPID())
+            .newPackage("p1", true)
+                .addDependency("p2")
+                .addDependency("p3")
+                .writeContent("prod1/p1.txt", "prod100 p1")
+                .getFeaturePack()
+            .newPackage("p2")
+                .writeContent("prod1/p2.txt", "prod100 p2")
+                .getFeaturePack()
+            .newPackage("p3")
+                .writeContent("prod1/p3.txt", "prod100 p3")
+                .getFeaturePack()
+            .newPackage("p4", true)
+                .writeContent("prod1/p4.txt", "prod100 p4")
+                .getFeaturePack()
+            .newPackage("common", true)
+                .writeContent("common.txt", "prod100");
+
+        prod101 = newFpl("prod1", "1", "1.0.1.Final");
+        creator.newFeaturePack(prod101.getFPID())
+            .newPackage("p1", true)
+                .addDependency("p2")
+                .addDependency("p3")
+                .writeContent("prod1/p101.txt", "prod101 p1")
+                .getFeaturePack()
+            .newPackage("p2")
+                .writeContent("prod1/p2.txt", "prod101 p2")
+                .getFeaturePack()
+            .newPackage("p3")
+                .writeContent("prod1/p3.txt", "prod101 p3")
+                .getFeaturePack()
+            .newPackage("p4", true)
+                .writeContent("prod1/p4.txt", "prod101 p4")
+                .getFeaturePack()
+            .newPackage("common", true)
+                .writeContent("common.txt", "prod101");
+
+        prod200 = newFpl("prod2", "1", "1.0.0.Final");
+        creator.newFeaturePack(prod200.getFPID())
+            .newPackage("p1", true)
+                .writeContent("prod2/p1.txt", "prod200 p1");
+
+        creator.install();
+    }
+
+    @Override
+    protected void testPm(ProvisioningManager pm) throws ProvisioningException {
+        pm.install(prod100);
+        writeContent("prod1/p1.txt", "user");
+        writeContent("prod1/p2.txt", "user");
+        writeContent("prod1/p3.txt", "user");
+        pm.install(prod101);
+        writeContent("prod1/p3.txt", "user2");
+        pm.install(prod200);
+        pm.undo();
+        pm.undo();
+    }
+
+
+    @Override
+    protected ProvisioningConfig provisionedConfig() throws ProvisioningDescriptionException {
+        return ProvisioningConfig.builder()
+                .addFeaturePackDep(FeaturePackConfig.builder(prod100).build())
+                .build();
+    }
+
+    @Override
+    protected ProvisionedState provisionedState() throws ProvisioningException {
+        return ProvisionedState.builder()
+                .addFeaturePack(ProvisionedFeaturePack.builder(prod100.getFPID())
+                        .addPackage("p1")
+                        .addPackage("p2")
+                        .addPackage("p3")
+                        .addPackage("p4")
+                        .addPackage("common")
+                        .build())
+                .build();
+    }
+
+    @Override
+    protected DirState provisionedHomeDir() {
+        return newDirBuilder()
+                .addFile("prod1/p1.txt", "user")
+                .addFile("prod1/p1.txt.glnew", "prod100 p1")
+                .addFile("prod1/p2.txt", "user")
+                .addFile("prod1/p2.txt.glnew", "prod100 p2")
+                .addFile("prod1/p3.txt", "user2")
+                .addFile("prod1/p3.txt.glnew", "prod100 p3")
+                .addFile("prod1/p4.txt", "prod100 p4")
+                .addFile("common.txt", "prod100")
+                .build();
+    }
+}

--- a/testsuite/src/test/java/org/jboss/galleon/userchanges/test/UserChangesAfterUndoTestCase.java
+++ b/testsuite/src/test/java/org/jboss/galleon/userchanges/test/UserChangesAfterUndoTestCase.java
@@ -14,12 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.galleon.undo.test;
 
-import java.io.File;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import org.jboss.galleon.Constants;
+package org.jboss.galleon.userchanges.test;
+
 import org.jboss.galleon.ProvisioningDescriptionException;
 import org.jboss.galleon.ProvisioningException;
 import org.jboss.galleon.ProvisioningManager;
@@ -31,81 +28,84 @@ import org.jboss.galleon.state.ProvisionedState;
 import org.jboss.galleon.test.util.fs.state.DirState;
 import org.jboss.galleon.universe.FeaturePackLocation;
 import org.jboss.galleon.universe.MvnUniverse;
-import org.jboss.galleon.universe.SingleUniverseTestBase;
-import org.jboss.galleon.util.PathsUtils;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 /**
  *
- * @author jdenise@redhat.com
+ * @author Alexey Loubyansky
  */
-public class ClearStateHistoryTestCase extends SingleUniverseTestBase {
+public class UserChangesAfterUndoTestCase extends UserChangesTestBase {
 
-    private FeaturePackLocation fp100;
-    private FeaturePackLocation fp101;
+    private FeaturePackLocation prod1;
+    private FeaturePackLocation prod2;
 
     @Override
     protected void createProducers(MvnUniverse universe) throws ProvisioningException {
         universe.createProducer("prod1");
+        universe.createProducer("prod2");
     }
 
     @Override
     protected void createFeaturePacks(FeaturePackCreator creator) throws ProvisioningException {
-        fp100 = newFpl("prod1", "1", "1.0.0.Final");
-        creator.newFeaturePack(fp100.getFPID())
-                .newPackage("p1", true)
-                .writeContent("fp1/p1.txt", "fp100 p1");
+        prod1 = newFpl("prod1", "1", "1.0.0.Final");
+        creator.newFeaturePack(prod1.getFPID())
+            .newPackage("p1", true)
+                .addDependency("p2")
+                .addDependency("p3")
+                .writeContent("prod1/p1.txt", "prod1 p1")
+                .getFeaturePack()
+            .newPackage("p2")
+                .writeContent("prod1/p2.txt", "prod1 p2")
+                .getFeaturePack()
+            .newPackage("p3")
+                .writeContent("prod1/p3.txt", "prod1 p3");
 
-        fp101 = newFpl("prod1", "1", "1.0.1.Final");
-        creator.newFeaturePack(fp101.getFPID())
-                .newPackage("p1", true)
-                .writeContent("fp1/p1.txt", "fp101 p1");
+        prod2 = newFpl("prod2", "1", "1.0.0.Final");
+        creator.newFeaturePack(prod2.getFPID())
+            .newPackage("p1", true)
+                .writeContent("prod2/p1.txt", "prod2 p1");
 
         creator.install();
     }
 
     @Override
-    protected ProvisioningConfig initialState() throws ProvisioningException {
-        return ProvisioningConfig.builder()
-                .addFeaturePackDep(fp100)
-                .build();
+    protected void testPm(ProvisioningManager pm) throws ProvisioningException {
+        pm.install(prod1);
+        pm.install(prod2);
+        writeContent("new.txt", "user");
+        writeContent("prod1/p2.txt", "user");
+        recursiveDelete("prod1/p3.txt");
+        mkdirs("prod1/user");
+        pm.undo();
     }
 
-    @Override
-    protected void testPm(ProvisioningManager pm) throws ProvisioningException {
-        pm.install(fp101);
-        assertTrue(pm.isUndoAvailable());
-        pm.clearStateHistory();
-        assertFalse(pm.isUndoAvailable());
-        Path installedHistoryDir = PathsUtils.getStateHistoryDir(installHome);
-        assertTrue(Files.exists(installedHistoryDir));
-        File[] files = installedHistoryDir.toFile().listFiles();
-        assertEquals(1, files.length);
-        assertTrue(files[0].getName().equals(Constants.HISTORY_LIST));
-    }
 
     @Override
     protected ProvisioningConfig provisionedConfig() throws ProvisioningDescriptionException {
         return ProvisioningConfig.builder()
-                .addFeaturePackDep(FeaturePackConfig.builder(fp101)
-                        .build()).build();
+                .addFeaturePackDep(FeaturePackConfig.builder(prod1)
+                        .build())
+                .build();
     }
 
     @Override
     protected ProvisionedState provisionedState() throws ProvisioningException {
         return ProvisionedState.builder()
-                .addFeaturePack(ProvisionedFeaturePack.builder(fp101.getFPID())
+                .addFeaturePack(ProvisionedFeaturePack.builder(prod1.getFPID())
                         .addPackage("p1")
-                        .build()).build();
+                        .addPackage("p2")
+                        .addPackage("p3")
+                        .build())
+                .build();
     }
 
     @Override
     protected DirState provisionedHomeDir() {
         return newDirBuilder()
-                .addFile("fp1/p1.txt", "fp101 p1")
+                .addFile("prod1/p1.txt", "prod1 p1")
+                .addFile("prod1/p2.txt", "user")
+                .addFile("prod1/p2.txt.glnew", "prod1 p2")
+                .addFile("new.txt", "user")
+                .addDir("prod1/user")
                 .build();
     }
 }

--- a/testsuite/src/test/java/org/jboss/galleon/userchanges/test/UserChangesAfterUninstallTestCase.java
+++ b/testsuite/src/test/java/org/jboss/galleon/userchanges/test/UserChangesAfterUninstallTestCase.java
@@ -14,12 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.galleon.undo.test;
 
-import java.io.File;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import org.jboss.galleon.Constants;
+package org.jboss.galleon.userchanges.test;
+
 import org.jboss.galleon.ProvisioningDescriptionException;
 import org.jboss.galleon.ProvisioningException;
 import org.jboss.galleon.ProvisioningManager;
@@ -31,81 +28,84 @@ import org.jboss.galleon.state.ProvisionedState;
 import org.jboss.galleon.test.util.fs.state.DirState;
 import org.jboss.galleon.universe.FeaturePackLocation;
 import org.jboss.galleon.universe.MvnUniverse;
-import org.jboss.galleon.universe.SingleUniverseTestBase;
-import org.jboss.galleon.util.PathsUtils;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 /**
  *
- * @author jdenise@redhat.com
+ * @author Alexey Loubyansky
  */
-public class ClearStateHistoryTestCase extends SingleUniverseTestBase {
+public class UserChangesAfterUninstallTestCase extends UserChangesTestBase {
 
-    private FeaturePackLocation fp100;
-    private FeaturePackLocation fp101;
+    private FeaturePackLocation prod1;
+    private FeaturePackLocation prod2;
 
     @Override
     protected void createProducers(MvnUniverse universe) throws ProvisioningException {
         universe.createProducer("prod1");
+        universe.createProducer("prod2");
     }
 
     @Override
     protected void createFeaturePacks(FeaturePackCreator creator) throws ProvisioningException {
-        fp100 = newFpl("prod1", "1", "1.0.0.Final");
-        creator.newFeaturePack(fp100.getFPID())
-                .newPackage("p1", true)
-                .writeContent("fp1/p1.txt", "fp100 p1");
+        prod1 = newFpl("prod1", "1", "1.0.0.Final");
+        creator.newFeaturePack(prod1.getFPID())
+            .newPackage("p1", true)
+                .addDependency("p2")
+                .addDependency("p3")
+                .writeContent("prod1/p1.txt", "prod1 p1")
+                .getFeaturePack()
+            .newPackage("p2")
+                .writeContent("prod1/p2.txt", "prod1 p2")
+                .getFeaturePack()
+            .newPackage("p3")
+                .writeContent("prod1/p3.txt", "prod1 p3");
 
-        fp101 = newFpl("prod1", "1", "1.0.1.Final");
-        creator.newFeaturePack(fp101.getFPID())
-                .newPackage("p1", true)
-                .writeContent("fp1/p1.txt", "fp101 p1");
+        prod2 = newFpl("prod2", "1", "1.0.0.Final");
+        creator.newFeaturePack(prod2.getFPID())
+            .newPackage("p1", true)
+                .writeContent("prod2/p1.txt", "prod2 p1");
 
         creator.install();
     }
 
     @Override
-    protected ProvisioningConfig initialState() throws ProvisioningException {
-        return ProvisioningConfig.builder()
-                .addFeaturePackDep(fp100)
-                .build();
+    protected void testPm(ProvisioningManager pm) throws ProvisioningException {
+        pm.install(prod1);
+        pm.install(prod2);
+        writeContent("new.txt", "user");
+        writeContent("prod1/p2.txt", "user");
+        recursiveDelete("prod1/p3.txt");
+        mkdirs("prod1/user");
+        pm.uninstall(prod2.getFPID());
     }
 
-    @Override
-    protected void testPm(ProvisioningManager pm) throws ProvisioningException {
-        pm.install(fp101);
-        assertTrue(pm.isUndoAvailable());
-        pm.clearStateHistory();
-        assertFalse(pm.isUndoAvailable());
-        Path installedHistoryDir = PathsUtils.getStateHistoryDir(installHome);
-        assertTrue(Files.exists(installedHistoryDir));
-        File[] files = installedHistoryDir.toFile().listFiles();
-        assertEquals(1, files.length);
-        assertTrue(files[0].getName().equals(Constants.HISTORY_LIST));
-    }
 
     @Override
     protected ProvisioningConfig provisionedConfig() throws ProvisioningDescriptionException {
         return ProvisioningConfig.builder()
-                .addFeaturePackDep(FeaturePackConfig.builder(fp101)
-                        .build()).build();
+                .addFeaturePackDep(FeaturePackConfig.builder(prod1)
+                        .build())
+                .build();
     }
 
     @Override
     protected ProvisionedState provisionedState() throws ProvisioningException {
         return ProvisionedState.builder()
-                .addFeaturePack(ProvisionedFeaturePack.builder(fp101.getFPID())
+                .addFeaturePack(ProvisionedFeaturePack.builder(prod1.getFPID())
                         .addPackage("p1")
-                        .build()).build();
+                        .addPackage("p2")
+                        .addPackage("p3")
+                        .build())
+                .build();
     }
 
     @Override
     protected DirState provisionedHomeDir() {
         return newDirBuilder()
-                .addFile("fp1/p1.txt", "fp101 p1")
+                .addFile("prod1/p1.txt", "prod1 p1")
+                .addFile("prod1/p2.txt", "user")
+                .addFile("prod1/p2.txt.glnew", "prod1 p2")
+                .addFile("new.txt", "user")
+                .addDir("prod1/user")
                 .build();
     }
 }

--- a/testsuite/src/test/java/org/jboss/galleon/userchanges/test/UserChangesAfterUpdatePlanTestCase.java
+++ b/testsuite/src/test/java/org/jboss/galleon/userchanges/test/UserChangesAfterUpdatePlanTestCase.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.galleon.userchanges.test;
+
+import org.jboss.galleon.ProvisioningDescriptionException;
+import org.jboss.galleon.ProvisioningException;
+import org.jboss.galleon.ProvisioningManager;
+import org.jboss.galleon.config.FeaturePackConfig;
+import org.jboss.galleon.config.ProvisioningConfig;
+import org.jboss.galleon.creator.FeaturePackCreator;
+import org.jboss.galleon.layout.ProvisioningPlan;
+import org.jboss.galleon.state.ProvisionedFeaturePack;
+import org.jboss.galleon.state.ProvisionedState;
+import org.jboss.galleon.test.util.fs.state.DirState;
+import org.jboss.galleon.universe.FeaturePackLocation;
+import org.jboss.galleon.universe.MvnUniverse;
+
+/**
+ *
+ * @author Alexey Loubyansky
+ */
+public class UserChangesAfterUpdatePlanTestCase extends UserChangesTestBase {
+
+    private FeaturePackLocation prod100;
+    private FeaturePackLocation prod101;
+    private FeaturePackLocation prod200;
+
+    @Override
+    protected void createProducers(MvnUniverse universe) throws ProvisioningException {
+        universe.createProducer("prod1");
+        universe.createProducer("prod2");
+    }
+
+    @Override
+    protected void createFeaturePacks(FeaturePackCreator creator) throws ProvisioningException {
+        prod100 = newFpl("prod1", "1", "1.0.0.Final");
+        creator.newFeaturePack(prod100.getFPID())
+            .newPackage("p1", true)
+                .addDependency("p2")
+                .addDependency("p3")
+                .writeContent("prod1/p1.txt", "prod1 p1")
+                .getFeaturePack()
+            .newPackage("p2")
+                .writeContent("prod1/p2.txt", "prod1 p2")
+                .getFeaturePack()
+            .newPackage("p3")
+                .writeContent("prod1/p3.txt", "prod1 p3");
+
+        prod101 = newFpl("prod1", "1", "1.0.1.Final");
+        creator.newFeaturePack(prod101.getFPID())
+            .newPackage("p1", true)
+                .addDependency("p2")
+                .addDependency("p3")
+                .writeContent("prod1/p1.txt", "prod101 p1")
+                .getFeaturePack()
+            .newPackage("p2")
+                .writeContent("prod1/p2.txt", "prod101 p2")
+                .getFeaturePack()
+            .newPackage("p3")
+                .writeContent("prod1/p3.txt", "prod101 p3");
+
+        prod200 = newFpl("prod2", "1", "1.0.0.Final");
+        creator.newFeaturePack(prod200.getFPID())
+            .newPackage("p1", true)
+                .writeContent("prod2/p1.txt", "prod2 p1");
+
+        creator.install();
+    }
+
+    @Override
+    protected void testPm(ProvisioningManager pm) throws ProvisioningException {
+        pm.install(prod100);
+        writeContent("new.txt", "user");
+        writeContent("prod1/p2.txt", "user");
+        recursiveDelete("prod1/p3.txt");
+        mkdirs("prod1/user");
+
+        pm.apply(ProvisioningPlan.builder()
+                .install(prod101)
+                .install(prod200));
+    }
+
+
+    @Override
+    protected ProvisioningConfig provisionedConfig() throws ProvisioningDescriptionException {
+        return ProvisioningConfig.builder()
+                .addFeaturePackDep(FeaturePackConfig.builder(prod101)
+                        .build())
+                .addFeaturePackDep(FeaturePackConfig.builder(prod200)
+                        .build())
+                .build();
+    }
+
+    @Override
+    protected ProvisionedState provisionedState() throws ProvisioningException {
+        return ProvisionedState.builder()
+                .addFeaturePack(ProvisionedFeaturePack.builder(prod101.getFPID())
+                        .addPackage("p1")
+                        .addPackage("p2")
+                        .addPackage("p3")
+                        .build())
+                .addFeaturePack(ProvisionedFeaturePack.builder(prod200.getFPID())
+                        .addPackage("p1")
+                        .build())
+                .build();
+    }
+
+    @Override
+    protected DirState provisionedHomeDir() {
+        return newDirBuilder()
+                .addFile("prod1/p1.txt", "prod101 p1")
+                .addFile("prod1/p2.txt", "user")
+                .addFile("prod1/p2.txt.glnew", "prod101 p2")
+                .addFile("prod2/p1.txt", "prod2 p1")
+                .addFile("new.txt", "user")
+                .addDir("prod1/user")
+                .build();
+    }
+}

--- a/testsuite/src/test/java/org/jboss/galleon/userchanges/test/UserChangesTestBase.java
+++ b/testsuite/src/test/java/org/jboss/galleon/userchanges/test/UserChangesTestBase.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.galleon.userchanges.test;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import org.jboss.galleon.universe.SingleUniverseTestBase;
+import org.jboss.galleon.util.IoUtils;
+
+/**
+ *
+ * @author Alexey Loubyansky
+ */
+public abstract class UserChangesTestBase extends SingleUniverseTestBase {
+
+    protected void writeContent(String relativePath, String content) {
+        try {
+            Files.createDirectories(installHome.resolve(relativePath).getParent());
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to create parent directories for " + relativePath, e);
+        }
+        try(BufferedWriter writer = Files.newBufferedWriter(installHome.resolve(relativePath))) {
+            writer.write(content);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to write to " + relativePath, e);
+        }
+    }
+
+    protected void recursiveDelete(String relativePath) {
+        IoUtils.recursiveDelete(installHome.resolve(relativePath));
+    }
+
+    protected void mkdirs(String relativePath) {
+        try {
+            Files.createDirectories(installHome.resolve(relativePath));
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to create directories " + relativePath, e);
+        }
+    }
+}


### PR DESCRIPTION
[GAL-170] Detect content changes to the last provisioned state and re-apply them after state update
[GAL-171] Turn history state file into a dir containing the config file describing the state
[GAL-172] When a patch is applied the feature-pack is patched in the layout cache