### PR TITLE
Fix for GAL-168 and upgrade to aesh 1.9

### DIFF
--- a/cli/src/main/java/org/jboss/galleon/cli/terminal/InteractivePmCommandInvocation.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/terminal/InteractivePmCommandInvocation.java
@@ -29,7 +29,6 @@ import org.aesh.command.validator.OptionValidatorException;
 import org.aesh.readline.AeshContext;
 import org.aesh.readline.Prompt;
 import org.aesh.readline.action.KeyAction;
-import org.aesh.utils.Config;
 import org.jboss.galleon.cli.PmCommandInvocation;
 import org.jboss.galleon.cli.PmSession;
 
@@ -89,8 +88,6 @@ class InteractivePmCommandInvocation extends PmCommandInvocation {
 
     @Override
     public void println(String msg) {
-        // Workaround Aesh 1.8 AESH-489 not adding \n at the end of line.
-        msg = msg + Config.getLineSeparator();
         delegate.println(msg, paging);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <version.junit>4.12</version.junit>
     <version.maven-aether-provider>3.3.9</version.maven-aether-provider>
     <version.maven-settings-builder>3.3.9</version.maven-settings-builder>
-    <version.org.aesh>1.8</version.org.aesh>
+    <version.org.aesh>1.9</version.org.aesh>
     <version.org.aesh-extensions>1.6</version.org.aesh-extensions>
     <version.org.apache.maven>3.3.1</version.org.apache.maven>
     <version.org.apache.maven.plugin-tools>${version.plugin.plugin}</version.org.apache.maven.plugin-tools>


### PR DESCRIPTION
- Removed workaround for GAL-167
- Upgrade to aesh 1.9