### PR TITLE
Fix for GAL-179, GAL-180, CLI help issues

### DIFF
--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/HelpCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/HelpCommand.java
@@ -25,6 +25,7 @@ import org.aesh.command.CommandDefinition;
 import org.aesh.command.CommandNotFoundException;
 import org.aesh.command.activator.CommandActivator;
 import org.aesh.command.completer.OptionCompleter;
+import org.aesh.command.container.CommandContainer;
 import org.aesh.command.impl.internal.ParsedCommand;
 import org.aesh.command.impl.parser.CommandLineParser;
 import org.aesh.command.invocation.CommandInvocation;
@@ -118,7 +119,18 @@ public class HelpCommand extends PmSessionCommand {
             for (String str : command) {
                 builder.append(str).append(" ");
             }
-            session.println(session.getHelpInfo(builder.toString()));
+            String cmd = builder.toString().trim();
+            try {
+                CommandContainer<?, ?> container = registry.getCommand(command.get(0), null);
+                if (command.size() > 1) {
+                    if (container.getParser().getChildParser(command.get(1)) == null) {
+                        throw new CommandExecutionException(CliErrors.commandNotFound(cmd));
+                    }
+                }
+            } catch (CommandNotFoundException ex) {
+                throw new CommandExecutionException(CliErrors.commandNotFound(cmd));
+            }
+            session.println(session.getHelpInfo(cmd));
         }
     }
 

--- a/cli/src/test/java/org/jboss/galleon/cli/HelpSupportTestCase.java
+++ b/cli/src/test/java/org/jboss/galleon/cli/HelpSupportTestCase.java
@@ -21,6 +21,7 @@ import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 
 import org.aesh.command.Command;
+import org.aesh.command.CommandException;
 import org.aesh.command.CommandRuntime;
 import org.aesh.command.impl.internal.ProcessedCommand;
 import org.aesh.command.impl.internal.ProcessedOption;
@@ -62,6 +63,30 @@ public class HelpSupportTestCase {
                     checkCommand(child.getProcessedCommand(), true);
                 }
             }
+        }
+    }
+
+    @Test
+    public void testUnknown() throws Exception {
+        PmSession session = new PmSession(Configuration.parse());
+        session.throwException();
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        CommandRuntime runtime
+                = CliMain.newRuntime(session, new PrintStream(out, false, StandardCharsets.UTF_8.name()));
+        try {
+            runtime.executeCommand("help foo");
+            throw new Exception("Should have failed");
+        } catch (CommandException ex) {
+            // XXX OK expected.
+        }
+        out.reset();
+        runtime.executeCommand("help filesystem ");
+        assertTrue(out.toString(), out.toString().contains("Usage: "));
+        try {
+            runtime.executeCommand("help filesystem foo");
+            throw new Exception("Should have failed");
+        } catch (CommandException ex) {
+            // XXX OK expected.
         }
     }
 


### PR DESCRIPTION
- Handle invalid command
- Complex command description was not displayed due to a lack of trimming.
