### PR TITLE
passive+ and runtime.close on error

### DIFF
--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/maingrp/InstallCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/maingrp/InstallCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * Copyright 2016-2019 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -186,7 +186,7 @@ public class InstallCommand extends AbstractPluginsCommand {
                 }
             } else {
                 if (!options.containsKey(Constants.OPTIONAL_PACKAGES)) {
-                    options.put(Constants.OPTIONAL_PACKAGES, Constants.PASSIVE);
+                    options.put(Constants.OPTIONAL_PACKAGES, Constants.PASSIVE_PLUS);
                 }
                 String configuration = (String) getValue(CONFIG_OPTION_NAME);
                 String model = null;

--- a/testsuite/src/test/java/org/jboss/galleon/cli/LayersTestCase.java
+++ b/testsuite/src/test/java/org/jboss/galleon/cli/LayersTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * Copyright 2016-2019 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -101,7 +101,7 @@ public class LayersTestCase {
         assertTrue(conf.getIncludedLayers().contains("layerC-" + PRODUCER1));
         String opt = config.getPluginOption(Constants.OPTIONAL_PACKAGES);
         assertNotNull(opt);
-        assertEquals(Constants.PASSIVE, opt);
+        assertEquals(Constants.PASSIVE_PLUS, opt);
 
         cli.execute("get-info --dir=" + path + " --type=configs");
         assertTrue(cli.getOutput(), cli.getOutput().contains("layerA-" + PRODUCER1));


### PR DESCRIPTION
- Installing layers take passive+ as default value
- close runtime if an exception occurs at state creation time.