### PR TITLE
Fix for GAL-236, CLI, Progress, wrong output for non ansi terminal

### DIFF
--- a/cli/src/main/java/org/jboss/galleon/cli/CliMain.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/CliMain.java
@@ -67,6 +67,7 @@ public class CliMain {
         try {
             pmSession = new PmSession(Configuration.parse(arguments.getOptions()), interactive);
             CliTerminalConnection connection = new CliTerminalConnection();
+            pmSession.setConnection(connection.getConnection());
             if (arguments.isHelp()) {
                 try {
                     CommandRuntime<? extends Command, ? extends CommandInvocation> runtime =

--- a/cli/src/main/java/org/jboss/galleon/cli/PmSession.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/PmSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * Copyright 2016-2019 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,6 +37,7 @@ import org.aesh.io.FileResource;
 import org.aesh.io.Resource;
 import org.aesh.readline.AeshContext;
 import org.aesh.readline.Prompt;
+import org.aesh.terminal.Connection;
 import org.aesh.utils.Config;
 import org.eclipse.aether.RepositoryEvent;
 import org.eclipse.aether.RepositoryListener;
@@ -273,7 +274,7 @@ public class PmSession implements CompleterInvocationProvider<PmCompleterInvocat
     private String promptRoot;
     private Path previousDir;
     private boolean commandRunning;
-
+    private Connection connection;
     public PmSession(Configuration config) throws Exception {
         this(config, true);
     }
@@ -668,5 +669,13 @@ public class PmSession implements CompleterInvocationProvider<PmCompleterInvocat
     }
     public void enableMavenTrace(boolean b) {
         mavenListener.setActive(b);
+    }
+
+    void setConnection(Connection connection) {
+        this.connection = connection;
+    }
+
+    public boolean isAnsiSupported() {
+        return connection != null && connection.supportsAnsi();
     }
 }

--- a/cli/src/main/java/org/jboss/galleon/cli/tracking/BuildLayoutTracker.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/tracking/BuildLayoutTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * Copyright 2016-2019 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,7 +29,7 @@ public class BuildLayoutTracker extends CliProgressTracker<FPID> {
     private final PmSession session;
 
     public BuildLayoutTracker(PmSession session) {
-        super("Resolving feature-pack", "Feature-packs resolved.");
+        super(session, "Resolving feature-pack", "Feature-packs resolved.");
         this.session = session;
     }
 

--- a/cli/src/main/java/org/jboss/galleon/cli/tracking/CliProgressTracker.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/tracking/CliProgressTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * Copyright 2016-2019 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,6 +20,7 @@ import org.aesh.readline.terminal.impl.WinSysTerminal;
 import org.aesh.utils.ANSI;
 import org.aesh.utils.Config;
 import org.jboss.galleon.cli.PmCommandInvocation;
+import org.jboss.galleon.cli.PmSession;
 import org.jboss.galleon.progresstracking.ProgressCallback;
 import org.jboss.galleon.progresstracking.ProgressTracker;
 
@@ -94,7 +95,7 @@ abstract class CliProgressTracker<T> implements ProgressCallback<T> {
     PmCommandInvocation invocation;
     private final Printer printer;
 
-    CliProgressTracker(String msgStart, String msgComplete) {
+    CliProgressTracker(PmSession session, String msgStart, String msgComplete) {
         this.msgStart = msgStart;
         this.msgComplete = msgComplete;
         if (Config.isWindows()) {
@@ -104,7 +105,11 @@ abstract class CliProgressTracker<T> implements ProgressCallback<T> {
                 printer = new BasicPrinter();
             }
         } else {
-            printer = new ANSIPrinter();
+            if(session.isAnsiSupported()) {
+                printer = new ANSIPrinter();
+            } else {
+                printer = new BasicPrinter();
+            }
         }
     }
 

--- a/cli/src/main/java/org/jboss/galleon/cli/tracking/ConfigsTracker.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/tracking/ConfigsTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * Copyright 2016-2019 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,7 @@
  */
 package org.jboss.galleon.cli.tracking;
 
+import org.jboss.galleon.cli.PmSession;
 import org.jboss.galleon.progresstracking.ProgressTracker;
 import org.jboss.galleon.state.ProvisionedConfig;
 
@@ -25,8 +26,8 @@ import org.jboss.galleon.state.ProvisionedConfig;
  */
 public class ConfigsTracker extends CliProgressTracker<ProvisionedConfig> {
 
-    public ConfigsTracker() {
-        super("Generating configuration", "Configurations generated.");
+    public ConfigsTracker(PmSession session) {
+        super(session, "Generating configuration", "Configurations generated.");
     }
 
     @Override

--- a/cli/src/main/java/org/jboss/galleon/cli/tracking/FindTracker.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/tracking/FindTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * Copyright 2016-2019 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,7 +29,7 @@ public class FindTracker extends CliProgressTracker<FPID> {
     private final PmSession session;
 
     public FindTracker(PmSession session) {
-        super("Searching in", "Search done.");
+        super(session, "Searching in", "Search done.");
         this.session = session;
     }
 

--- a/cli/src/main/java/org/jboss/galleon/cli/tracking/JBossModulesTracker.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/tracking/JBossModulesTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * Copyright 2016-2019 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,7 @@
  */
 package org.jboss.galleon.cli.tracking;
 
+import org.jboss.galleon.cli.PmSession;
 import org.jboss.galleon.progresstracking.ProgressTracker;
 import org.jboss.galleon.runtime.PackageRuntime;
 
@@ -26,8 +27,8 @@ import org.jboss.galleon.runtime.PackageRuntime;
  */
 public class JBossModulesTracker extends CliProgressTracker<PackageRuntime> {
 
-    public JBossModulesTracker() {
-        super("Installing JBoss modules", "JBoss modules installed.");
+    public JBossModulesTracker(PmSession session) {
+        super(session, "Installing JBoss modules", "JBoss modules installed.");
     }
 
     @Override

--- a/cli/src/main/java/org/jboss/galleon/cli/tracking/PackagesTracker.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/tracking/PackagesTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * Copyright 2016-2019 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,7 @@
  */
 package org.jboss.galleon.cli.tracking;
 
+import org.jboss.galleon.cli.PmSession;
 import org.jboss.galleon.progresstracking.ProgressTracker;
 import org.jboss.galleon.runtime.PackageRuntime;
 
@@ -25,8 +26,8 @@ import org.jboss.galleon.runtime.PackageRuntime;
  */
 public class PackagesTracker extends CliProgressTracker<PackageRuntime> {
 
-    public PackagesTracker() {
-        super("Installing packages", "Packages installed.");
+    public PackagesTracker(PmSession session) {
+        super(session, "Installing packages", "Packages installed.");
     }
 
     @Override

--- a/cli/src/main/java/org/jboss/galleon/cli/tracking/ProgressTrackers.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/tracking/ProgressTrackers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * Copyright 2016-2019 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -68,12 +68,12 @@ public abstract class ProgressTrackers {
             BuildLayoutTracker layout = new BuildLayoutTracker(session);
             trackers.put(ProvisioningLayoutFactory.TRACK_LAYOUT_BUILD, layout);
 
-            PackagesTracker packages = new PackagesTracker();
+            PackagesTracker packages = new PackagesTracker(session);
             trackers.put(ProvisioningLayoutFactory.TRACK_PACKAGES, packages);
 
-            trackers.put("JBMODULES", new JBossModulesTracker());
+            trackers.put("JBMODULES", new JBossModulesTracker(session));
 
-            ConfigsTracker configs = new ConfigsTracker();
+            ConfigsTracker configs = new ConfigsTracker(session);
             trackers.put(ProvisioningLayoutFactory.TRACK_CONFIGS, configs);
 
             UpdatesTracker updates = new UpdatesTracker(session);

--- a/cli/src/main/java/org/jboss/galleon/cli/tracking/UpdatesTracker.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/tracking/UpdatesTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * Copyright 2016-2019 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,7 +29,7 @@ public class UpdatesTracker extends CliProgressTracker<ProducerSpec> {
     private final PmSession session;
 
     public UpdatesTracker(PmSession session) {
-        super("Looking for update for", null);
+        super(session, "Looking for update for", null);
         this.session = session;
     }
 


### PR DESCRIPTION
Check that the connection to terminal supports ANSI when initializing tracker.