### PR TITLE
Fix for GAL-259, CLI, Including, excluding packages and transitive dependency issues

### DIFF
--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/state/AbstractFPProvisionedCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/state/AbstractFPProvisionedCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * Copyright 2016-2019 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -42,13 +42,18 @@ public abstract class AbstractFPProvisionedCommand extends AbstractStateCommand 
     }
 
     public FeaturePackConfig getProvisionedFP(PmSession session) throws CommandExecutionException {
-        ProducerSpec channel = getProducer(session);
-        if (channel == null) {
+        ProducerSpec producer = getProducer(session);
+        if (producer == null) {
             return null;
         }
         ProvisioningConfig config = session.getState().getConfig();
         for (FeaturePackConfig dep : config.getFeaturePackDeps()) {
-            if (dep.getLocation().getProducer().equals(channel)) {
+            if (dep.getLocation().getProducer().equals(producer)) {
+                return dep;
+            }
+        }
+        for (FeaturePackConfig dep : config.getTransitiveDeps()) {
+            if (dep.getLocation().getProducer().equals(producer)) {
                 return dep;
             }
         }

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/state/pkg/AbstractProvisionedPackageCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/state/pkg/AbstractProvisionedPackageCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * Copyright 2016-2019 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -53,6 +53,13 @@ public abstract class AbstractProvisionedPackageCommand extends AbstractFPProvis
                 if (fp == null) {
                     // We want them all from all FP
                     for (FeaturePackConfig fc : completerInvocation.getPmSession().getState().getConfig().getFeaturePackDeps()) {
+                        for (String pkg : cmd.getTargetedPackages(fc)) {
+                            if (!packages.contains(pkg)) {
+                                packages.add(pkg);
+                            }
+                        }
+                    }
+                    for (FeaturePackConfig fc : completerInvocation.getPmSession().getState().getConfig().getTransitiveDeps()) {
                         for (String pkg : cmd.getTargetedPackages(fc)) {
                             if (!packages.contains(pkg)) {
                                 packages.add(pkg);

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/state/pkg/PackagesUtil.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/state/pkg/PackagesUtil.java
@@ -59,6 +59,11 @@ public class PackagesUtil {
                     packages.put(c, pkg);
                 }
             }
+            for (FeaturePackConfig c : session.getState().getConfig().getTransitiveDeps()) {
+                if (c.getIncludedPackages().contains(pkg)) {
+                    packages.put(c, pkg);
+                }
+            }
         } else {
             if (config.getIncludedPackages().contains(pkg)) {
                 packages.put(config, pkg);
@@ -74,6 +79,11 @@ public class PackagesUtil {
         Map<FeaturePackConfig, String> packages = new HashMap<>();
         if (config == null) {
             for (FeaturePackConfig c : session.getState().getConfig().getFeaturePackDeps()) {
+                if (c.getExcludedPackages().contains(pkg)) {
+                    packages.put(c, pkg);
+                }
+            }
+            for (FeaturePackConfig c : session.getState().getConfig().getTransitiveDeps()) {
                 if (c.getExcludedPackages().contains(pkg)) {
                     packages.put(c, pkg);
                 }

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/state/pkg/ProvisionedPackageCommandActivator.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/state/pkg/ProvisionedPackageCommandActivator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * Copyright 2016-2019 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,6 +30,11 @@ public class ProvisionedPackageCommandActivator extends AbstractCommandActivator
     public boolean isActivated(ParsedCommand command) {
         AbstractProvisionedPackageCommand cmd = (AbstractProvisionedPackageCommand) command.command();
         for (FeaturePackConfig cf : getSession().getState().getConfig().getFeaturePackDeps()) {
+            if (!cmd.getTargetedPackages(cf).isEmpty()) {
+                return true;
+            }
+        }
+        for (FeaturePackConfig cf : getSession().getState().getConfig().getTransitiveDeps()) {
             if (!cmd.getTargetedPackages(cf).isEmpty()) {
                 return true;
             }

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/state/pkg/StateExcludePackageCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/state/pkg/StateExcludePackageCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * Copyright 2016-2019 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,7 +38,15 @@ public class StateExcludePackageCommand extends AbstractPackageCommand {
     @Override
     protected void runCommand(PmCommandInvocation invoc, State session, FeaturePackConfig config) throws IOException, ProvisioningException, CommandExecutionException {
         try {
-            session.excludePackage(invoc.getPmSession(), PackagesUtil.getPackage(invoc.getPmSession(), config.getLocation().getFPID(), getPackage()), config);
+            int i = getPackage().indexOf("/");
+            String name = getPackage().substring(i + 1);
+            // If the config is null, it means that the package exists in a transitive dependency
+            // but no transitive dependency has been created yet.
+            if (config == null) {
+                session.excludePackageFromNewTransitive(invoc.getPmSession(), getProducer(invoc.getPmSession()), name);
+            } else {
+                session.excludePackage(invoc.getPmSession(), name, config);
+            }
         } catch (Exception ex) {
             throw new CommandExecutionException(invoc.getPmSession(), CliErrors.excludeFailed(), ex);
         }

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/state/pkg/StateIncludePackageCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/state/pkg/StateIncludePackageCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * Copyright 2016-2019 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,7 +38,15 @@ public class StateIncludePackageCommand extends AbstractPackageCommand {
     @Override
     protected void runCommand(PmCommandInvocation invoc, State session, FeaturePackConfig config) throws IOException, ProvisioningException, CommandExecutionException {
         try {
-            session.includePackage(invoc.getPmSession(), PackagesUtil.getPackage(invoc.getPmSession(), config.getLocation().getFPID(), getPackage()), config);
+            int i = getPackage().indexOf("/");
+            String name = getPackage().substring(i + 1);
+            // If the config is null, it means that the package exists in a transitive dependency
+            // but no transitive dependency has been created yet.
+            if (config == null) {
+                session.includePackageInNewTransitive(invoc.getPmSession(), getProducer(invoc.getPmSession()), name);
+            } else {
+                session.includePackage(invoc.getPmSession(), name, config);
+            }
         } catch (Exception ex) {
             throw new CommandExecutionException(invoc.getPmSession(), CliErrors.includeFailed(), ex);
         }

--- a/cli/src/main/java/org/jboss/galleon/cli/model/state/State.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/model/state/State.java
@@ -45,6 +45,7 @@ import org.jboss.galleon.config.ProvisioningConfig;
 import org.jboss.galleon.runtime.FeaturePackRuntime;
 import org.jboss.galleon.runtime.ProvisioningRuntime;
 import org.jboss.galleon.runtime.ProvisioningRuntimeBuilder;
+import org.jboss.galleon.universe.FeaturePackLocation.ProducerSpec;
 import org.jboss.galleon.xml.ProvisioningXmlParser;
 import org.jboss.galleon.xml.ProvisioningXmlWriter;
 
@@ -247,6 +248,16 @@ public class State {
 
     public void defineConfiguration(PmSession pmSession, ConfigId id) throws ProvisioningException, IOException {
         Action action = configProvisioning.newConfiguration(id);
+        config = pushState(action, pmSession);
+    }
+
+    public void excludePackageFromNewTransitive(PmSession pmSession, ProducerSpec producer, String pkg) throws ProvisioningException, IOException {
+        Action action = fpProvisioning.excludePackageFromNewTransitive(producer, pkg);
+        config = pushState(action, pmSession);
+    }
+
+    public void includePackageInNewTransitive(PmSession pmSession, ProducerSpec producer, String pkg) throws ProvisioningException, IOException {
+        Action action = fpProvisioning.includePackageInNewTransitive(producer, pkg);
         config = pushState(action, pmSession);
     }
 

--- a/core/src/main/java/org/jboss/galleon/config/FeaturePackDepsConfigBuilder.java
+++ b/core/src/main/java/org/jboss/galleon/config/FeaturePackDepsConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * Copyright 2016-2019 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -150,6 +150,10 @@ public abstract class FeaturePackDepsConfigBuilder<B extends FeaturePackDepsConf
 
     public boolean hasFeaturePackDep(ProducerSpec producer) {
         return fpDeps.containsKey(producer);
+    }
+
+    public boolean hasTransitiveFeaturePackDep(ProducerSpec producer) {
+        return transitiveDeps.containsKey(producer);
     }
 
     public boolean hasFeaturePackDeps() {

--- a/testsuite/src/test/java/org/jboss/galleon/cli/CliTestUtils.java
+++ b/testsuite/src/test/java/org/jboss/galleon/cli/CliTestUtils.java
@@ -52,6 +52,7 @@ public abstract class CliTestUtils {
     public static final String PRODUCER1 = "producer1";
     public static final String PRODUCER2 = "producer2";
     public static final String PRODUCER3 = "producer3";
+    public static final String PRODUCER4 = "producer4";
     public static final String UNIVERSE_NAME = "cli-test-universe";
 
     public static ProvisioningConfig getConfig(Path dir) throws ProvisioningException {


### PR DESCRIPTION
- include/exclude packages for transitive dep.
- remove included/excluded for transitive dep.
- Automatically add a transitive dep when first including/excluding a package
- Remove empty transitive (not configured and no version) when removing included/excluded.
- Added tests