### PR TITLE
Fix for GAL-262, Installed galleon1 FP breaks update

### DIFF
--- a/core/src/main/java/org/jboss/galleon/universe/galleon1/LegacyGalleon1Channel.java
+++ b/core/src/main/java/org/jboss/galleon/universe/galleon1/LegacyGalleon1Channel.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.jboss.galleon.ProvisioningException;
 import org.jboss.galleon.universe.Channel;
 import org.jboss.galleon.universe.FeaturePackLocation;
+import org.jboss.galleon.universe.LatestVersionNotAvailableException;
 
 /**
  *
@@ -62,7 +63,7 @@ public class LegacyGalleon1Channel implements Channel {
 
     @Override
     public String getLatestBuild(FeaturePackLocation fpl) throws ProvisioningException {
-        throw new ProvisioningException("Failed to determine the latest build for " + fpl + ": operation not supported");
+        throw new LatestVersionNotAvailableException(fpl);
     }
 
     @Override
@@ -72,7 +73,7 @@ public class LegacyGalleon1Channel implements Channel {
 
     @Override
     public String getLatestBuild(FeaturePackLocation.FPID fpid) throws ProvisioningException {
-        throw new UnsupportedOperationException("Not supported yet.");
+        throw new LatestVersionNotAvailableException(fpid.getLocation());
     }
 
     @Override

--- a/core/src/test/java/org/jboss/galleon/installation/fpversions/MissingFpVersionTestCase.java
+++ b/core/src/test/java/org/jboss/galleon/installation/fpversions/MissingFpVersionTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * Copyright 2016-2019 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -72,7 +72,7 @@ public class MissingFpVersionTestCase extends PmProvisionConfigTestBase {
     @Override
     protected String[] pmErrors() throws ProvisioningException {
         return new String[] {
-                "Failed to determine the latest build for " + FP1_GA + ": operation not supported"
+            "No version is available for " + FP1_GA
         };
     }
 }

--- a/core/src/test/java/org/jboss/galleon/installation/fpversions/MissingFpVersionsTestCase.java
+++ b/core/src/test/java/org/jboss/galleon/installation/fpversions/MissingFpVersionsTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * Copyright 2016-2019 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -74,7 +74,7 @@ public class MissingFpVersionsTestCase extends PmProvisionConfigTestBase {
     @Override
     protected String[] pmErrors() throws ProvisioningException {
         return new String[] {
-                "Failed to determine the latest build for " + FP3_GA + ": operation not supported"
+            "No version is available for " + FP3_GA
         };
     }
 }


### PR DESCRIPTION
Throw proper exception to not update galleon1 FP.