### PR TITLE
[GAL-276] CLI: install producer#build displays null as the channel in the report

### DIFF
--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/maingrp/InstallCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/maingrp/InstallCommand.java
@@ -204,8 +204,8 @@ public class InstallCommand extends AbstractPluginsCommand {
                         config, loc).build(), options);
             }
             session.println("Feature pack installed.");
-            if(manager.isRecordState()) {
-                if (!loc.hasBuild()) {
+            if(manager.isRecordState() && !loc.isMavenCoordinates()) {
+                if (!loc.hasBuild() || loc.getChannelName() == null) {
                     loc = manager.getProvisioningConfig().getFeaturePackDep(loc.getProducer()).getLocation();
                 }
                 StateInfoUtil.printFeaturePack(session,


### PR DESCRIPTION
https://issues.jboss.org/browse/GAL-276