### PR TITLE
[GAL-277], [GAL-278]

### DIFF
--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/featurepack/GetInfoCommand.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/featurepack/GetInfoCommand.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import org.aesh.command.CommandDefinition;
 import org.aesh.command.option.Option;
 import org.jboss.galleon.ProvisioningException;
-import org.jboss.galleon.ProvisioningManager;
 import org.jboss.galleon.cli.AbstractCompleter;
 import org.jboss.galleon.cli.CommandExecutionException;
 import org.jboss.galleon.cli.HelpDescriptions;
@@ -215,7 +214,6 @@ public class GetInfoCommand extends AbstractFeaturePackCommand {
         try (ProvisioningRuntime rt = ProvisioningRuntimeBuilder.
                 newInstance(commandInvocation.getPmSession().getMessageWriter(false))
                 .initRtLayout(pLayout.transform(ProvisioningRuntimeBuilder.FP_RT_FACTORY))
-                .setEncoding(ProvisioningManager.Builder.ENCODING)
                 .build()) {
             for (ProvisionedConfig m : rt.getConfigs()) {
                 String model = m.getModel();
@@ -259,7 +257,6 @@ public class GetInfoCommand extends AbstractFeaturePackCommand {
         try (ProvisioningRuntime rt = ProvisioningRuntimeBuilder.
                 newInstance(commandInvocation.getPmSession().getMessageWriter(false))
                 .initRtLayout(pLayout.transform(ProvisioningRuntimeBuilder.FP_RT_FACTORY))
-                .setEncoding(ProvisioningManager.Builder.ENCODING)
                 .build()) {
             FeatureContainer container = FeatureContainers.
                     fromProvisioningRuntime(commandInvocation.getPmSession(), rt);

--- a/cli/src/main/java/org/jboss/galleon/cli/model/FeatureContainers.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/model/FeatureContainers.java
@@ -27,7 +27,6 @@ import java.util.Set;
 import org.jboss.galleon.Constants;
 
 import org.jboss.galleon.ProvisioningException;
-import org.jboss.galleon.ProvisioningManager;
 import org.jboss.galleon.ProvisioningOption;
 import org.jboss.galleon.cli.PmSession;
 import org.jboss.galleon.config.FeaturePackConfig;
@@ -333,7 +332,6 @@ public abstract class FeatureContainers {
         ProvisioningConfig provisioning = ProvisioningConfig.builder().addFeaturePackDep(config).build();
         ProvisioningRuntime runtime = ProvisioningRuntimeBuilder.newInstance(pmSession.getMessageWriter(false))
                 .initLayout(pmSession.getLayoutFactory(), provisioning)
-                .setEncoding(ProvisioningManager.Builder.ENCODING)
                 .build();
         return runtime;
     }

--- a/cli/src/main/java/org/jboss/galleon/cli/model/state/State.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/model/state/State.java
@@ -30,7 +30,6 @@ import java.util.Set;
 import org.jboss.galleon.universe.FeaturePackLocation;
 import org.jboss.galleon.util.PathsUtils;
 import org.jboss.galleon.ProvisioningException;
-import org.jboss.galleon.ProvisioningManager;
 import org.jboss.galleon.cli.PmSession;
 import org.jboss.galleon.cli.model.ConfigInfo;
 import org.jboss.galleon.cli.model.FeatureContainer;
@@ -114,7 +113,6 @@ public class State {
         config = builder.build();
         runtime = ProvisioningRuntimeBuilder.newInstance(pmSession.getMessageWriter(false))
                 .initLayout(pmSession.getLayoutFactory(), config)
-                .setEncoding(ProvisioningManager.Builder.ENCODING)
                 .build();
         container = FeatureContainers.fromProvisioningRuntime(pmSession, runtime);
         container.setEdit(true);
@@ -309,7 +307,6 @@ public class State {
         }
         runtime = ProvisioningRuntimeBuilder.newInstance(pmSession.getMessageWriter(false))
                 .initLayout(pmSession.getLayoutFactory(), tmp)
-                .setEncoding(ProvisioningManager.Builder.ENCODING)
                 .build();
         try {
             Set<FeaturePackLocation.FPID> dependencies = new HashSet<>();

--- a/core/src/main/java/org/jboss/galleon/ProvisioningManager.java
+++ b/core/src/main/java/org/jboss/galleon/ProvisioningManager.java
@@ -65,8 +65,6 @@ import org.jboss.galleon.xml.ProvisioningXmlWriter;
 public class ProvisioningManager implements AutoCloseable {
 
     public static class Builder extends UniverseResolverBuilder<Builder> {
-        public static final String ENCODING = "UTF-8";
-        private String encoding = ENCODING;
         private Path installationHome;
         private ProvisioningLayoutFactory layoutFactory;
         private MessageWriter messageWriter;
@@ -75,11 +73,6 @@ public class ProvisioningManager implements AutoCloseable {
         private boolean recordState = true;
 
         private Builder() {
-        }
-
-        public Builder setEncoding(String encoding) {
-            this.encoding = encoding;
-            return this;
         }
 
         public Builder setInstallationHome(Path installationHome) {
@@ -148,7 +141,6 @@ public class ProvisioningManager implements AutoCloseable {
         return new Builder();
     }
 
-    private final String encoding;
     private final Path home;
     private final MessageWriter log;
     private boolean logTime;
@@ -162,7 +154,6 @@ public class ProvisioningManager implements AutoCloseable {
     private ProvisioningManager(Builder builder) throws ProvisioningException {
         PathsUtils.assertInstallationDir(builder.installationHome);
         this.home = builder.installationHome;
-        this.encoding = builder.encoding;
         this.log = builder.messageWriter == null ? DefaultMessageWriter.getDefaultInstance() : builder.messageWriter;
         if(builder.layoutFactory != null) {
             layoutFactory = builder.layoutFactory;
@@ -638,7 +629,6 @@ public class ProvisioningManager implements AutoCloseable {
             throws ProvisioningException {
         final ProvisioningRuntimeBuilder rtBuilder = ProvisioningRuntimeBuilder.newInstance(log)
                 .initRtLayout(layout)
-                .setEncoding(encoding)
                 .setLogTime(logTime)
                 .setFsDiff(fsDiff)
                 .setRecordState(recordState);

--- a/core/src/main/java/org/jboss/galleon/runtime/ProvisioningRuntimeBuilder.java
+++ b/core/src/main/java/org/jboss/galleon/runtime/ProvisioningRuntimeBuilder.java
@@ -84,7 +84,6 @@ public class ProvisioningRuntimeBuilder {
 
     long startTime;
     boolean logTime;
-    String encoding;
     ProvisioningConfig config;
     ProvisioningLayout<FeaturePackRuntimeBuilder> layout;
     Path stagedDir;
@@ -115,11 +114,6 @@ public class ProvisioningRuntimeBuilder {
 
     private ProvisioningRuntimeBuilder(final MessageWriter messageWriter) {
         this.messageWriter = messageWriter;
-    }
-
-    public ProvisioningRuntimeBuilder setEncoding(String encoding) {
-        this.encoding = encoding;
-        return this;
     }
 
     public ProvisioningRuntimeBuilder setLogTime(boolean logTime) {

--- a/core/src/main/java/org/jboss/galleon/xml/util/FormattingXmlStreamWriter.java
+++ b/core/src/main/java/org/jboss/galleon/xml/util/FormattingXmlStreamWriter.java
@@ -48,7 +48,7 @@ public final class FormattingXmlStreamWriter implements XMLStreamWriter, XMLStre
     }
 
     private void nl() throws XMLStreamException {
-        delegate.writeCharacters("\n");
+        delegate.writeCharacters(System.lineSeparator());
     }
 
     private void indent() throws XMLStreamException {


### PR DESCRIPTION
https://issues.jboss.org/browse/GAL-277
[GAL-277] Formatting XML writer should use platform dependent line separator

https://issues.jboss.org/browse/GAL-278
[GAL-278] Provisioning manager encoding setting is used nowhere