### PR TITLE
[GAL-280] Allow regex based include/exclude version filtering when re…

### DIFF
--- a/maven-plugin/src/main/java/org/jboss/galleon/maven/plugin/ChannelDescription.java
+++ b/maven-plugin/src/main/java/org/jboss/galleon/maven/plugin/ChannelDescription.java
@@ -37,6 +37,18 @@ public class ChannelDescription implements MavenChannelDescription {
     @Parameter(required = true)
     String versionRange;
 
+    /**
+     * Producer artifact version inclusion filter
+     */
+    @Parameter
+    String versionIncludeRegex;
+
+    /**
+     * Producer artifact version exclusion filter
+     */
+    @Parameter
+    String versionExcludeRegex;
+
     @Override
     public String getName() {
         return name;
@@ -45,5 +57,15 @@ public class ChannelDescription implements MavenChannelDescription {
     @Override
     public String getVersionRange() {
         return versionRange;
+    }
+
+    @Override
+    public String getVersionIncludeRegex() {
+        return versionIncludeRegex;
+    }
+
+    @Override
+    public String getVersionExcludeRegex() {
+        return versionExcludeRegex;
     }
 }

--- a/maven-universe/src/main/java/org/jboss/galleon/universe/maven/MavenChannelDescription.java
+++ b/maven-universe/src/main/java/org/jboss/galleon/universe/maven/MavenChannelDescription.java
@@ -25,4 +25,8 @@ public interface MavenChannelDescription {
     String getName();
 
     String getVersionRange();
+
+    String getVersionIncludeRegex();
+
+    String getVersionExcludeRegex();
 }

--- a/maven-universe/src/main/java/org/jboss/galleon/universe/maven/MavenProducerInstaller.java
+++ b/maven-universe/src/main/java/org/jboss/galleon/universe/maven/MavenProducerInstaller.java
@@ -147,6 +147,11 @@ public class MavenProducerInstaller extends MavenProducerBase {
         return addChannel(new MavenChannel(this, channelName, versionRange), isDefault);
     }
 
+    public MavenProducerInstaller addChannel(String channelName, String versionRange, boolean isDefault,
+                                             String includeVersionRegex, String excludeVersionRegex) throws MavenUniverseException {
+        return addChannel(new MavenChannel(this, channelName, versionRange, includeVersionRegex, excludeVersionRegex), isDefault);
+    }
+
     public MavenProducerInstaller addChannel(MavenChannel channel) throws MavenUniverseException {
         channels.put(channel.getName(), channel);
         return this;

--- a/maven-universe/src/main/java/org/jboss/galleon/universe/maven/repo/MavenArtifactVersion.java
+++ b/maven-universe/src/main/java/org/jboss/galleon/universe/maven/repo/MavenArtifactVersion.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.regex.Pattern;
 
 import org.jboss.galleon.universe.maven.MavenUniverseException;
 
@@ -42,6 +43,11 @@ public class MavenArtifactVersion implements Comparable<MavenArtifactVersion> {
     }
 
     public static MavenArtifactVersion getLatest(Iterable<?> versions, String lowestQualifier) throws MavenUniverseException {
+        return getLatest(versions, lowestQualifier, null, null);
+    }
+
+    public static MavenArtifactVersion getLatest(Iterable<?> versions, String lowestQualifier,
+                                                 Pattern includeVersion, Pattern excludeVersion) throws MavenUniverseException {
         final boolean snapshotsAllowed;
         if (lowestQualifier == null) {
             lowestQualifier = "";
@@ -53,6 +59,12 @@ public class MavenArtifactVersion implements Comparable<MavenArtifactVersion> {
         String latestSnapshot = null;
         for (Object version : versions) {
             final String v = version.toString();
+            if (includeVersion != null && !includeVersion.matcher(v).matches()) {
+                continue;
+            }
+            if (excludeVersion != null && excludeVersion.matcher(v).matches()) {
+                continue;
+            }
             final boolean snapshot = isSnapshot(v);
             final MavenArtifactVersion next;
             if(snapshot) {

--- a/maven-universe/src/main/java/org/jboss/galleon/universe/maven/repo/MavenRepoManager.java
+++ b/maven-universe/src/main/java/org/jboss/galleon/universe/maven/repo/MavenRepoManager.java
@@ -21,6 +21,7 @@ import org.jboss.galleon.universe.maven.MavenUniverseException;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import org.jboss.galleon.ProvisioningException;
 import org.jboss.galleon.repo.RepositoryArtifactResolver;
@@ -64,6 +65,8 @@ public interface MavenRepoManager extends RepositoryArtifactResolver {
         resolveLatestVersion(artifact, lowestQualifier, false);
     }
 
+    void resolveLatestVersion(MavenArtifact artifact, String lowestQualifier, Pattern includeVersion, Pattern excludeVersion) throws MavenUniverseException;
+
     void resolveLatestVersion(MavenArtifact artifact, String lowestQualifier, boolean locallyAvailable) throws MavenUniverseException;
 
     default String getLatestFinalVersion(MavenArtifact artifact) throws MavenUniverseException {
@@ -74,7 +77,11 @@ public interface MavenRepoManager extends RepositoryArtifactResolver {
 
     String getLatestVersion(MavenArtifact artifact, String lowestQualifier) throws MavenUniverseException;
 
+    String getLatestVersion(MavenArtifact artifact, String lowestQualifier, Pattern includeVersion, Pattern excludeVersion) throws MavenUniverseException;
+
     List<String> getAllVersions(MavenArtifact artifact) throws MavenUniverseException;
+
+    List<String> getAllVersions(MavenArtifact artifact, Pattern includeVersion, Pattern excludeVersion) throws MavenUniverseException;
 
     void install(MavenArtifact artifact, Path path) throws MavenUniverseException;
 }

--- a/maven-universe/src/main/java/org/jboss/galleon/universe/maven/repo/SimplisticMavenRepoManager.java
+++ b/maven-universe/src/main/java/org/jboss/galleon/universe/maven/repo/SimplisticMavenRepoManager.java
@@ -21,6 +21,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.regex.Pattern;
+
 import org.jboss.galleon.ProvisioningException;
 import org.jboss.galleon.universe.maven.MavenUniverseException;
 import org.jboss.galleon.universe.maven.MavenArtifact;
@@ -111,7 +113,7 @@ public class SimplisticMavenRepoManager extends LocalArtifactVersionRangeResolve
                     throw e;
                 }
             }
-            fallback.resolveLatestVersion(artifact, lowestQualifier);
+            fallback.resolveLatestVersion(artifact, lowestQualifier, locally);
             return;
         }
         if(locally) {
@@ -121,20 +123,26 @@ public class SimplisticMavenRepoManager extends LocalArtifactVersionRangeResolve
         if(fallback == null) {
             throw new MavenUniverseException(MavenErrors.failedToResolveLatestVersion(artifact.getCoordsAsString()));
         }
+
         fallback.resolveLatestVersion(artifact, lowestQualifier);
     }
 
     @Override
     public void resolveLatestVersion(MavenArtifact artifact, String lowestQualifier) throws MavenUniverseException {
+        resolveLatestVersion(artifact, lowestQualifier, null, null);
+    }
+
+    @Override
+    public void resolveLatestVersion(MavenArtifact artifact, String lowestQualifier, Pattern includeVersion, Pattern excludeVersion) throws MavenUniverseException {
         try {
-            super.resolveLatestVersion(artifact, lowestQualifier);
+            super.resolveLatestVersion(artifact, lowestQualifier, includeVersion, excludeVersion);
             return;
         } catch(MavenUniverseException e) {
             if(fallback == null) {
                 throw e;
             }
         }
-        fallback.resolveLatestVersion(artifact, lowestQualifier);
+        fallback.resolveLatestVersion(artifact, lowestQualifier, includeVersion, excludeVersion);
     }
 
     @Override
@@ -193,6 +201,11 @@ public class SimplisticMavenRepoManager extends LocalArtifactVersionRangeResolve
 
     @Override
     public List<String> getAllVersions(MavenArtifact artifact) throws MavenUniverseException {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+
+    @Override
+    public List<String> getAllVersions(MavenArtifact artifact, Pattern includeVersion, Pattern excludeVersion) throws MavenUniverseException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }

--- a/maven-universe/src/main/java/org/jboss/galleon/universe/maven/xml/MavenChannelSpecXmlParser10.java
+++ b/maven-universe/src/main/java/org/jboss/galleon/universe/maven/xml/MavenChannelSpecXmlParser10.java
@@ -47,6 +47,8 @@ public class MavenChannelSpecXmlParser10 implements PlugableXmlParser<ParsedCall
 
         CHANNEL("channel"),
         VERSION_RANGE("version-range"),
+        VERSION_INCLUDE_REGEX("version-include-regex"),
+        VERSION_EXCLUDE_REGEX("version-exclude-regex"),
 
         // default unknown element
         UNKNOWN(null);
@@ -57,6 +59,8 @@ public class MavenChannelSpecXmlParser10 implements PlugableXmlParser<ParsedCall
             elements = new HashMap<>(3);
             elements.put(new QName(NAMESPACE_1_0, CHANNEL.name), CHANNEL);
             elements.put(new QName(NAMESPACE_1_0, VERSION_RANGE.name), VERSION_RANGE);
+            elements.put(new QName(NAMESPACE_1_0, VERSION_INCLUDE_REGEX.name), VERSION_INCLUDE_REGEX);
+            elements.put(new QName(NAMESPACE_1_0, VERSION_EXCLUDE_REGEX.name), VERSION_EXCLUDE_REGEX);
             elements.put(null, UNKNOWN);
         }
 
@@ -164,11 +168,13 @@ public class MavenChannelSpecXmlParser10 implements PlugableXmlParser<ParsedCall
             throw ParsingUtils.missingAttributes(reader.getLocation(), Collections.singleton(Attribute.NAME));
         }
         String versionRange = null;
+        String versionIncludeRegex = null;
+        String versionExcludeRegex = null;
         while (reader.hasNext()) {
             switch (reader.nextTag()) {
                 case XMLStreamConstants.END_ELEMENT: {
                     try {
-                        builder.parsed(new MavenChannel(builder.getParent(), name, versionRange));
+                        builder.parsed(new MavenChannel(builder.getParent(), name, versionRange, versionIncludeRegex, versionExcludeRegex));
                     } catch (MavenUniverseException e) {
                         throw new XMLStreamException(getParserMessage("Failed to parse producer", reader.getLocation()), e);
                     }
@@ -179,6 +185,12 @@ public class MavenChannelSpecXmlParser10 implements PlugableXmlParser<ParsedCall
                     switch (element) {
                         case VERSION_RANGE:
                             versionRange = reader.getElementText();
+                            break;
+                        case VERSION_INCLUDE_REGEX:
+                            versionIncludeRegex = reader.getElementText();
+                            break;
+                        case VERSION_EXCLUDE_REGEX:
+                            versionExcludeRegex = reader.getElementText();
                             break;
                         default:
                             throw ParsingUtils.unexpectedContent(reader);

--- a/maven-universe/src/main/java/org/jboss/galleon/universe/maven/xml/MavenChannelSpecXmlWriter.java
+++ b/maven-universe/src/main/java/org/jboss/galleon/universe/maven/xml/MavenChannelSpecXmlWriter.java
@@ -46,6 +46,14 @@ public class MavenChannelSpecXmlWriter extends BaseXmlWriter<MavenChannelDescrip
             throw new XMLStreamException("Channel " + channel.getName() + " is missing version-range");
         }
         addElement(producerEl, Element.VERSION_RANGE).addChild(new TextNode(value));
+        String includeRegex = channel.getVersionIncludeRegex();
+        if (includeRegex != null) {
+            addElement(producerEl, Element.VERSION_INCLUDE_REGEX).addChild(new TextNode(includeRegex));
+        }
+        String excludeRegex = channel.getVersionExcludeRegex();
+        if (excludeRegex != null) {
+            addElement(producerEl, Element.VERSION_EXCLUDE_REGEX).addChild(new TextNode(excludeRegex));
+        }
         return producerEl;
     }
 

--- a/testsuite/src/test/java/org/jboss/galleon/universe/MvnUniverse.java
+++ b/testsuite/src/test/java/org/jboss/galleon/universe/MvnUniverse.java
@@ -70,12 +70,17 @@ public class MvnUniverse {
     }
 
     public MvnUniverse createProducer(String producerName, String fpArtifactId, String defaultFrequency) throws ProvisioningException {
+        return createProducer(producerName, fpArtifactId, defaultFrequency, null, null);
+    }
+
+    public MvnUniverse createProducer(String producerName, String fpArtifactId, String defaultFrequency,
+                                      String includeVersionRegex, String excludeVersionRegex) throws ProvisioningException {
         final MavenProducerInstaller producer = new MavenProducerInstaller(producerName, repoManager,
                 new MavenArtifact().setGroupId(TestConstants.GROUP_ID + '.' + name).setArtifactId(producerName)
                         .setVersion("1.0.0.Final"),
                 TestConstants.GROUP_ID + '.' + name + '.' + producerName, fpArtifactId)
                         .addFrequencies(frequencies)
-                        .addChannel("1", "[1.0.0-alpha,2.0.0-alpha)");
+                        .addChannel("1", "[1.0.0-alpha,2.0.0-alpha)", false, includeVersionRegex, excludeVersionRegex);
         if(defaultFrequency != null) {
             producer.addFrequency(defaultFrequency, true);
         }

--- a/testsuite/src/test/java/org/jboss/galleon/universe/channel/filter/test/ChannelExcludeMatchFailTestCase.java
+++ b/testsuite/src/test/java/org/jboss/galleon/universe/channel/filter/test/ChannelExcludeMatchFailTestCase.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2016-2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.galleon.universe.channel.filter.test;
+
+import org.jboss.galleon.Errors;
+import org.jboss.galleon.ProvisioningException;
+import org.jboss.galleon.config.ProvisioningConfig;
+import org.jboss.galleon.creator.FeaturePackCreator;
+import org.jboss.galleon.universe.FeaturePackLocation;
+import org.jboss.galleon.universe.FeaturePackLocation.FPID;
+import org.jboss.galleon.universe.ProvisionConfigMvnTestBase;
+import org.jboss.galleon.universe.maven.MavenArtifact;
+import org.jboss.galleon.universe.maven.MavenUniverseFactory;
+
+/**
+ *
+ * @author Brian Stansberry
+ */
+public class ChannelExcludeMatchFailTestCase extends ProvisionConfigMvnTestBase {
+
+    private static final String EXT_REGEX = ".*-ext-[0-9][0-9][0-9][0-9][0-9]";
+    private static final FeaturePackLocation EXT_FPL = FeaturePackLocation.fromString("producer1:1#1.1.1.Final-ext-00001");
+    private static final FeaturePackLocation EXT2_FPL = FeaturePackLocation.fromString("producer1:1#1.1.1.Final-ext-00002");
+
+    private MavenArtifact universe1Art;
+    private FPID extFpid;
+    private FPID ext2Fpid;
+
+    @Override
+    protected void createFeaturePacks(FeaturePackCreator creator) throws ProvisioningException {
+
+        universe1Art = newMvnUniverse("universe1")
+                .createProducer("producer1", "fp1", "final", null, EXT_REGEX)
+                .install();
+
+        extFpid = mvnFPID(EXT_FPL, universe1Art);
+        ext2Fpid = mvnFPID(EXT2_FPL, universe1Art);
+
+        creator.newFeaturePack()
+            .setFPID(extFpid)
+            .newPackage("p1", true)
+                .writeContent("fp1/p1.txt", "p1 ext");
+
+        creator.newFeaturePack()
+            .setFPID(ext2Fpid)
+            .newPackage("p1", true)
+                .writeContent("fp1/p1.txt", "p1 ext2");
+
+        creator.install();
+    }
+
+    @Override
+    protected ProvisioningConfig provisioningConfig() throws ProvisioningException {
+        return ProvisioningConfig.builder()
+                .setDefaultUniverse(MavenUniverseFactory.ID, universe1Art.getCoordsAsString())
+                .addFeaturePackDep(FeaturePackLocation.fromString("producer1:1"))
+                .build();
+    }
+
+    @Override
+    protected ProvisioningConfig provisionedConfig() throws ProvisioningException {
+        return ProvisioningConfig.builder()
+        .setDefaultUniverse(MavenUniverseFactory.ID, universe1Art.getCoordsAsString())
+        .addFeaturePackDep(FeaturePackLocation.fromString("producer1:1#1.1.0.Final"))
+        .build();
+    }
+
+
+    @Override
+    protected String[] pmErrors() {
+        return new String[] {
+                Errors.noVersionAvailable(FeaturePackLocation.fromString("producer1@maven(org.jboss.galleon.universe.test:universe1:jar:1.0.0.Final):1/final"))
+        };
+    }
+}

--- a/testsuite/src/test/java/org/jboss/galleon/universe/channel/filter/test/ChannelExcludeMatchTestCase.java
+++ b/testsuite/src/test/java/org/jboss/galleon/universe/channel/filter/test/ChannelExcludeMatchTestCase.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2016-2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.galleon.universe.channel.filter.test;
+
+import org.jboss.galleon.ProvisioningException;
+import org.jboss.galleon.config.ProvisioningConfig;
+import org.jboss.galleon.creator.FeaturePackCreator;
+import org.jboss.galleon.state.ProvisionedFeaturePack;
+import org.jboss.galleon.state.ProvisionedState;
+import org.jboss.galleon.test.util.fs.state.DirState;
+import org.jboss.galleon.universe.FeaturePackLocation;
+import org.jboss.galleon.universe.FeaturePackLocation.FPID;
+import org.jboss.galleon.universe.ProvisionConfigMvnTestBase;
+import org.jboss.galleon.universe.maven.MavenArtifact;
+import org.jboss.galleon.universe.maven.MavenUniverseFactory;
+
+/**
+ *
+ * @author Brian Stansberry
+ */
+public class ChannelExcludeMatchTestCase extends ProvisionConfigMvnTestBase {
+
+    private static final String EXT_REGEX = ".*-ext-[0-9][0-9][0-9][0-9][0-9]";
+    private static final FeaturePackLocation STD_FPL = FeaturePackLocation.fromString("producer1:1#1.1.0.Final");
+    private static final FeaturePackLocation EXT_FPL = FeaturePackLocation.fromString("producer1:1#1.1.1.Final-ext-00001");
+
+    private MavenArtifact universe1Art;
+    private FPID stdFpid;
+    private FPID extFpid;
+
+    @Override
+    protected void createFeaturePacks(FeaturePackCreator creator) throws ProvisioningException {
+
+        universe1Art = newMvnUniverse("universe1")
+                .createProducer("producer1", "fp1", "final", null, EXT_REGEX)
+                .install();
+
+        stdFpid = mvnFPID(STD_FPL, universe1Art);
+        extFpid = mvnFPID(EXT_FPL, universe1Art);
+
+        creator.newFeaturePack()
+            .setFPID(stdFpid)
+            .newPackage("p1", true)
+                .writeContent("fp1/p1.txt", "p1 std");
+
+        creator.newFeaturePack()
+            .setFPID(extFpid)
+            .newPackage("p1", true)
+                .writeContent("fp1/p1.txt", "p1 ext");
+
+        creator.install();
+    }
+
+    @Override
+    protected ProvisioningConfig provisioningConfig() throws ProvisioningException {
+        return ProvisioningConfig.builder()
+                .setDefaultUniverse(MavenUniverseFactory.ID, universe1Art.getCoordsAsString())
+                .addFeaturePackDep(FeaturePackLocation.fromString("producer1:1"))
+                .build();
+    }
+
+    @Override
+    protected ProvisioningConfig provisionedConfig() throws ProvisioningException {
+        return ProvisioningConfig.builder()
+        .setDefaultUniverse(MavenUniverseFactory.ID, universe1Art.getCoordsAsString())
+        .addFeaturePackDep(FeaturePackLocation.fromString("producer1:1#1.1.0.Final"))
+        .build();
+    }
+
+    @Override
+    protected ProvisionedState provisionedState() throws ProvisioningException {
+        return ProvisionedState.builder()
+                .addFeaturePack(ProvisionedFeaturePack.builder(stdFpid)
+                        .addPackage("p1")
+                        .build())
+                .build();
+    }
+
+    @Override
+    protected DirState provisionedHomeDir() {
+        return newDirBuilder()
+                .addFile("fp1/p1.txt", "p1 std")
+                .build();
+    }
+}

--- a/testsuite/src/test/java/org/jboss/galleon/universe/channel/filter/test/ChannelIncludeExcludeMatchTestCase.java
+++ b/testsuite/src/test/java/org/jboss/galleon/universe/channel/filter/test/ChannelIncludeExcludeMatchTestCase.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2016-2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.galleon.universe.channel.filter.test;
+
+import org.jboss.galleon.ProvisioningException;
+import org.jboss.galleon.config.ProvisioningConfig;
+import org.jboss.galleon.creator.FeaturePackCreator;
+import org.jboss.galleon.state.ProvisionedFeaturePack;
+import org.jboss.galleon.state.ProvisionedState;
+import org.jboss.galleon.test.util.fs.state.DirState;
+import org.jboss.galleon.universe.FeaturePackLocation;
+import org.jboss.galleon.universe.FeaturePackLocation.FPID;
+import org.jboss.galleon.universe.ProvisionConfigMvnTestBase;
+import org.jboss.galleon.universe.maven.MavenArtifact;
+import org.jboss.galleon.universe.maven.MavenUniverseFactory;
+
+/**
+ *
+ * @author Brian Stansberry
+ */
+public class ChannelIncludeExcludeMatchTestCase extends ProvisionConfigMvnTestBase {
+
+    private static final String INCL_REGEX = ".*-ext-[0-9][0-9][0-9][0-9][0-9]";
+    private static final String EXCL_REGEX = ".*-ext-01234";
+    private static final FeaturePackLocation STD_FPL = FeaturePackLocation.fromString("producer1:1#1.2.0.Final");
+    private static final FeaturePackLocation EXT_FPL = FeaturePackLocation.fromString("producer1:1#1.1.1.Final-ext-01233");
+    private static final FeaturePackLocation EXT2_FPL = FeaturePackLocation.fromString("producer1:1#1.1.2.Final-ext-01234");
+
+    private MavenArtifact universe1Art;
+    private FPID stdFpid;
+    private FPID extFpid;
+    private FPID ext2Fpid;
+
+    @Override
+    protected void createFeaturePacks(FeaturePackCreator creator) throws ProvisioningException {
+
+        universe1Art = newMvnUniverse("universe1")
+                .createProducer("producer1", "fp1", "final", INCL_REGEX, EXCL_REGEX)
+                .install();
+
+        stdFpid = mvnFPID(STD_FPL, universe1Art);
+        extFpid = mvnFPID(EXT_FPL, universe1Art);
+        ext2Fpid = mvnFPID(EXT2_FPL, universe1Art);
+
+        creator.newFeaturePack()
+            .setFPID(stdFpid)
+            .newPackage("p1", true)
+                .writeContent("fp1/p1.txt", "p1 std");
+
+        creator.newFeaturePack()
+            .setFPID(extFpid)
+            .newPackage("p1", true)
+                .writeContent("fp1/p1.txt", "p1 ext");
+
+        creator.newFeaturePack()
+                .setFPID(ext2Fpid)
+                .newPackage("p1", true)
+                .writeContent("fp1/p1.txt", "p1 ext2");
+
+        creator.install();
+    }
+
+    @Override
+    protected ProvisioningConfig provisioningConfig() throws ProvisioningException {
+        return ProvisioningConfig.builder()
+                .setDefaultUniverse(MavenUniverseFactory.ID, universe1Art.getCoordsAsString())
+                .addFeaturePackDep(FeaturePackLocation.fromString("producer1:1"))
+                .build();
+    }
+
+    @Override
+    protected ProvisioningConfig provisionedConfig() throws ProvisioningException {
+        return ProvisioningConfig.builder()
+        .setDefaultUniverse(MavenUniverseFactory.ID, universe1Art.getCoordsAsString())
+        .addFeaturePackDep(FeaturePackLocation.fromString("producer1:1#1.1.1.Final-ext-01233"))
+        .build();
+    }
+
+    @Override
+    protected ProvisionedState provisionedState() throws ProvisioningException {
+        return ProvisionedState.builder()
+                .addFeaturePack(ProvisionedFeaturePack.builder(extFpid)
+                        .addPackage("p1")
+                        .build())
+                .build();
+    }
+
+    @Override
+    protected DirState provisionedHomeDir() {
+        return newDirBuilder()
+                .addFile("fp1/p1.txt", "p1 ext")
+                .build();
+    }
+}

--- a/testsuite/src/test/java/org/jboss/galleon/universe/channel/filter/test/ChannelIncludeMatchFailTestCase.java
+++ b/testsuite/src/test/java/org/jboss/galleon/universe/channel/filter/test/ChannelIncludeMatchFailTestCase.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2016-2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.galleon.universe.channel.filter.test;
+
+import org.jboss.galleon.Errors;
+import org.jboss.galleon.ProvisioningException;
+import org.jboss.galleon.config.ProvisioningConfig;
+import org.jboss.galleon.creator.FeaturePackCreator;
+import org.jboss.galleon.universe.FeaturePackLocation;
+import org.jboss.galleon.universe.FeaturePackLocation.FPID;
+import org.jboss.galleon.universe.ProvisionConfigMvnTestBase;
+import org.jboss.galleon.universe.maven.MavenArtifact;
+import org.jboss.galleon.universe.maven.MavenUniverseFactory;
+
+/**
+ *
+ * @author Brian Stansberry
+ */
+public class ChannelIncludeMatchFailTestCase extends ProvisionConfigMvnTestBase {
+
+    private static final String ALT_REGEX = ".*-alt-[0-9][0-9][0-9][0-9][0-9]";
+    private static final FeaturePackLocation EXT_FPL = FeaturePackLocation.fromString("producer1:1#1.1.1.Final-ext-00001");
+    private static final FeaturePackLocation EXT2_FPL = FeaturePackLocation.fromString("producer1:1#1.1.1.Final-ext-00002");
+
+    private MavenArtifact universe1Art;
+    private FPID extFpid;
+    private FPID ext2Fpid;
+
+    @Override
+    protected void createFeaturePacks(FeaturePackCreator creator) throws ProvisioningException {
+
+        universe1Art = newMvnUniverse("universe1")
+                .createProducer("producer1", "fp1", "final", ALT_REGEX, null)
+                .install();
+
+        extFpid = mvnFPID(EXT_FPL, universe1Art);
+        ext2Fpid = mvnFPID(EXT2_FPL, universe1Art);
+
+        creator.newFeaturePack()
+            .setFPID(extFpid)
+            .newPackage("p1", true)
+                .writeContent("fp1/p1.txt", "p1 ext");
+
+        creator.newFeaturePack()
+            .setFPID(ext2Fpid)
+            .newPackage("p1", true)
+                .writeContent("fp1/p1.txt", "p1 ext2");
+
+        creator.install();
+    }
+
+    @Override
+    protected ProvisioningConfig provisioningConfig() throws ProvisioningException {
+        return ProvisioningConfig.builder()
+                .setDefaultUniverse(MavenUniverseFactory.ID, universe1Art.getCoordsAsString())
+                .addFeaturePackDep(FeaturePackLocation.fromString("producer1:1"))
+                .build();
+    }
+
+    @Override
+    protected ProvisioningConfig provisionedConfig() throws ProvisioningException {
+        return ProvisioningConfig.builder()
+        .setDefaultUniverse(MavenUniverseFactory.ID, universe1Art.getCoordsAsString())
+        .addFeaturePackDep(FeaturePackLocation.fromString("producer1:1#1.1.0.Final"))
+        .build();
+    }
+
+
+    @Override
+    protected String[] pmErrors() {
+        return new String[] {
+                Errors.noVersionAvailable(FeaturePackLocation.fromString("producer1@maven(org.jboss.galleon.universe.test:universe1:jar:1.0.0.Final):1/final"))
+        };
+    }
+}

--- a/testsuite/src/test/java/org/jboss/galleon/universe/channel/filter/test/ChannelIncludeMatchTestCase.java
+++ b/testsuite/src/test/java/org/jboss/galleon/universe/channel/filter/test/ChannelIncludeMatchTestCase.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2016-2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.galleon.universe.channel.filter.test;
+
+import org.jboss.galleon.ProvisioningException;
+import org.jboss.galleon.config.ProvisioningConfig;
+import org.jboss.galleon.creator.FeaturePackCreator;
+import org.jboss.galleon.state.ProvisionedFeaturePack;
+import org.jboss.galleon.state.ProvisionedState;
+import org.jboss.galleon.test.util.fs.state.DirState;
+import org.jboss.galleon.universe.FeaturePackLocation;
+import org.jboss.galleon.universe.FeaturePackLocation.FPID;
+import org.jboss.galleon.universe.ProvisionConfigMvnTestBase;
+import org.jboss.galleon.universe.maven.MavenArtifact;
+import org.jboss.galleon.universe.maven.MavenUniverseFactory;
+
+/**
+ *
+ * @author Brian Stansberry
+ */
+public class ChannelIncludeMatchTestCase extends ProvisionConfigMvnTestBase {
+
+    private static final String EXT_REGEX = ".*-ext-[0-9][0-9][0-9][0-9][0-9]";
+    private static final FeaturePackLocation STD_FPL = FeaturePackLocation.fromString("producer1:1#1.1.1.Final");
+    private static final FeaturePackLocation EXT_FPL = FeaturePackLocation.fromString("producer1:1#1.1.0.Final-ext-00001");
+
+    private MavenArtifact universe1Art;
+    private FPID stdFpid;
+    private FPID extFpid;
+
+    @Override
+    protected void createFeaturePacks(FeaturePackCreator creator) throws ProvisioningException {
+
+        universe1Art = newMvnUniverse("universe1")
+                .createProducer("producer1", "fp1", "final", EXT_REGEX, null)
+                .install();
+
+        stdFpid = mvnFPID(STD_FPL, universe1Art);
+        extFpid = mvnFPID(EXT_FPL, universe1Art);
+
+        creator.newFeaturePack()
+            .setFPID(stdFpid)
+            .newPackage("p1", true)
+                .writeContent("fp1/p1.txt", "p1 std");
+
+        creator.newFeaturePack()
+            .setFPID(extFpid)
+            .newPackage("p1", true)
+                .writeContent("fp1/p1.txt", "p1 ext");
+
+        creator.install();
+    }
+
+    @Override
+    protected ProvisioningConfig provisioningConfig() throws ProvisioningException {
+        return ProvisioningConfig.builder()
+                .setDefaultUniverse(MavenUniverseFactory.ID, universe1Art.getCoordsAsString())
+                .addFeaturePackDep(FeaturePackLocation.fromString("producer1:1"))
+                .build();
+    }
+
+    @Override
+    protected ProvisioningConfig provisionedConfig() throws ProvisioningException {
+        return ProvisioningConfig.builder()
+        .setDefaultUniverse(MavenUniverseFactory.ID, universe1Art.getCoordsAsString())
+        .addFeaturePackDep(FeaturePackLocation.fromString("producer1:1#1.1.0.Final-ext-00001"))
+        .build();
+    }
+
+    @Override
+    protected ProvisionedState provisionedState() throws ProvisioningException {
+        return ProvisionedState.builder()
+                .addFeaturePack(ProvisionedFeaturePack.builder(extFpid)
+                        .addPackage("p1")
+                        .build())
+                .build();
+    }
+
+    @Override
+    protected DirState provisionedHomeDir() {
+        return newDirBuilder()
+                .addFile("fp1/p1.txt", "p1 ext")
+                .build();
+    }
+}

--- a/testsuite/src/test/java/org/jboss/galleon/universe/maven/test/MavenProducerExtendAndInstallTestCase.java
+++ b/testsuite/src/test/java/org/jboss/galleon/universe/maven/test/MavenProducerExtendAndInstallTestCase.java
@@ -57,7 +57,7 @@ public class MavenProducerExtendAndInstallTestCase extends UniverseRepoTestBase 
         MavenProducerInstaller producerInstaller = new MavenProducerInstaller("producer1", repo, producer100Artifact, fpGroupId, fpArtifactId);
         producerInstaller.addFrequencies("alpha", "beta");
         producerInstaller.addChannel("1.0", "[1.0.0,2.0.0)");
-        producerInstaller.addChannel("2.0", "[2.0.0,3.0.0)");
+        producerInstaller.addChannel("2.0", "[2.0.0,3.0.0)", false, ".*-ext-[0-9][0-9]", ".*-ext-11");
         producerInstaller.install();
 
         producerInstaller = new MavenProducerInstaller("producer1", repo, producer101Artifact, producer100Artifact);
@@ -79,6 +79,8 @@ public class MavenProducerExtendAndInstallTestCase extends UniverseRepoTestBase 
         Assert.assertEquals(fpGroupId, channel.getFeaturePackGroupId());
         Assert.assertEquals(fpArtifactId, channel.getFeaturePackArtifactId());
         Assert.assertEquals("[2.0.0,3.0.0)", channel.getVersionRange());
+        Assert.assertEquals(".*-ext-[0-9][0-9]", channel.getVersionIncludeRegex());
+        Assert.assertEquals(".*-ext-11", channel.getVersionExcludeRegex());
         frequencies = channel.getFrequencies();
         Assert.assertEquals(3, frequencies.size());
         Assert.assertTrue(frequencies.contains("alpha"));

--- a/testsuite/src/test/java/org/jboss/galleon/universe/maven/test/MavenProducerInstallTestCase.java
+++ b/testsuite/src/test/java/org/jboss/galleon/universe/maven/test/MavenProducerInstallTestCase.java
@@ -54,7 +54,7 @@ public class MavenProducerInstallTestCase extends UniverseRepoTestBase {
         final MavenProducerInstaller producerInstaller = new MavenProducerInstaller("producer1", repo, producerArtifact, fpGroupId, fpArtifactId);
         producerInstaller.addFrequencies("alpha", "beta");
         producerInstaller.addChannel("1.0", "[1.0.0,2.0.0)");
-        producerInstaller.addChannel("2.0", "[2.0.0,3.0.0)");
+        producerInstaller.addChannel("2.0", "[2.0.0,3.0.0)", false, ".*-ext-[0-9][0-9]", ".*-ext-11");
         producerInstaller.install();
 
         producerArtifact.setPath(null);
@@ -82,6 +82,8 @@ public class MavenProducerInstallTestCase extends UniverseRepoTestBase {
         Assert.assertEquals(fpGroupId, channel.getFeaturePackGroupId());
         Assert.assertEquals(fpArtifactId, channel.getFeaturePackArtifactId());
         Assert.assertEquals("[2.0.0,3.0.0)", channel.getVersionRange());
+        Assert.assertEquals(".*-ext-[0-9][0-9]", channel.getVersionIncludeRegex());
+        Assert.assertEquals(".*-ext-11", channel.getVersionExcludeRegex());
         frequencies = channel.getFrequencies();
         Assert.assertEquals(3, frequencies.size());
         Assert.assertTrue(frequencies.contains("alpha"));


### PR DESCRIPTION
…solving feature packs from channels

https://issues.jboss.org/browse/GAL-280

@aloubyansky @jfdenise FYI.

I add two new elements to the channel spec xml, version-include-regex and version-exclude-regex, which result in ChannelDescription.getVersion[In|Ex]cludeRegex.  Those get compiled in MavenChannel into a Pattern, which MavenChannel passes into new overloaded variants of the MavenRepoManager methods it calls. The MavenRepoManager impls match maven versions against those patterns if they are provided.

The maven plugin config uses new properties 'versionIncludeRegex' and 'versionExcludeRegex' to set these when generating the producer.

I didn't bump the version of the xml namespace for the channel spec to reflect the new elements. It looked like all the various parsers were still at 1.0 so I decided to be lazy and assume the schemas weren't being advanced. I can change that of course.

Conceivably filtering on more than the version might be wanted, but for the use case I can imagine, it's the version that matters.

I didn't add overloaded variants of other MavenRepoManager methods besides the ones MavenChannel needs. Originally I did, just to be consistent, but that added conceptual bloat to the change and increased risk of bugs. Since this issue is about filtering what's associated with a Channel it seemed reasonable to limit things to what was needed for that use case.