### PR TITLE
[GAL-290] MavenChannel.resolve should validate any build specified in…

### DIFF
--- a/maven-universe/src/main/java/org/jboss/galleon/universe/maven/MavenChannel.java
+++ b/maven-universe/src/main/java/org/jboss/galleon/universe/maven/MavenChannel.java
@@ -105,7 +105,7 @@ public class MavenChannel implements Channel, MavenChannelDescription {
     }
 
     @Override
-    public Path resolve(FeaturePackLocation fpl) throws MavenUniverseException {
+    public Path resolve(FeaturePackLocation fpl) throws ProvisioningException {
         final MavenArtifact artifact = new MavenArtifact();
         artifact.setGroupId(producer.getFeaturePackGroupId());
         artifact.setArtifactId(producer.getFeaturePackArtifactId());
@@ -115,7 +115,22 @@ public class MavenChannel implements Channel, MavenChannelDescription {
             artifact.setVersionRange(versionRange);
             producer.getRepo().resolveLatestVersion(artifact, getFrequency(fpl), versionIncludePattern, versionExcludePattern);
         } else {
-            artifact.setVersion(fpl.getBuild());
+            String build = fpl.getBuild();
+
+            // Make sure this build conforms to the specification of this Channel.
+            // Iterating a list isn't great but MavenRepoManager provides a list and other callers of
+            // getAllVersions request a list so converting to a Set would require care
+            // Iterate from the end of the list under the assumption that older versions less likely to be requested
+            boolean valid = false;
+            List<String> allBuilds = getAllBuilds(fpl);
+            for (int i = allBuilds.size() - 1; !valid && i >= 0; i--) {
+                valid = build.equals(allBuilds.get(i));
+            }
+            if (!valid) {
+                throw new MavenUniverseException(String.format("%s is not a valid build for channel %s", build, name));
+            }
+
+            artifact.setVersion(build);
             producer.getRepo().resolve(artifact);
         }
         return artifact.getPath();

--- a/maven-universe/src/main/java/org/jboss/galleon/universe/maven/repo/SimplisticMavenRepoManager.java
+++ b/maven-universe/src/main/java/org/jboss/galleon/universe/maven/repo/SimplisticMavenRepoManager.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -201,11 +203,21 @@ public class SimplisticMavenRepoManager extends LocalArtifactVersionRangeResolve
 
     @Override
     public List<String> getAllVersions(MavenArtifact artifact) throws MavenUniverseException {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        return getAllVersions(artifact, null, null);
     }
 
     @Override
     public List<String> getAllVersions(MavenArtifact artifact, Pattern includeVersion, Pattern excludeVersion) throws MavenUniverseException {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        if(artifact.getGroupId() == null) {
+            MavenErrors.missingGroupId();
+        }
+        Path p = repoHome;
+        final String[] groupParts = artifact.getGroupId().split("\\.");
+        for (String part : groupParts) {
+            p = p.resolve(part);
+        }
+
+        String[] children = p.resolve(artifact.getArtifactId()).toFile().list();
+        return children == null ? Collections.emptyList() : Arrays.asList(children);
     }
 }


### PR DESCRIPTION
… the FPL against the builds provided by the channel

https://issues.jboss.org/browse/GAL-290

This goes beyond the specific issue in that it should catch other cases where the specified build does not match what the channel provides (frequency or version range.)

This isn't a particularly elegant solution, but it seemed like adding an overloaded resolve method to MavenRepoManager to pass in the channel's various constraints would end up with an impl that does much the same kind of thing.

@aloubyansky or @jfdenise if you have any suggestions for how to test this please let me know. I added tests for GAL-280 that involve specifying a particular build but they must not be exercising the GAL-290 call path.