### PR TITLE
Fix for GAL-296 and GAL-297

### DIFF
--- a/cli/src/main/java/org/jboss/galleon/cli/HelpDescriptions.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/HelpDescriptions.java
@@ -16,6 +16,8 @@
  */
 package org.jboss.galleon.cli;
 
+import org.jboss.galleon.cli.cmd.maingrp.LayersConfigBuilder;
+
 /**
  *
  * @author jdenise@redhat.com
@@ -105,7 +107,11 @@ public interface HelpDescriptions {
             + "The configuration model is optional, it is retrieved from the feature-pack content";
     String INSTALL_DEFAULT_CONFIGS = "A comma separated list of <configuration model>/<configuration name>";
     String INSTALL_IN_UNIVERSE = "Install feature pack to universe. Optional, it is installed by default";
-    String INSTALL_LAYERS = "Comma seperated list of layers";
+    String INSTALL_LAYERS = "Comma separated list of layers to provision. "
+            + "In order to exclude an optional layer on which a layer from the list depends on, "
+            + "prefix the excluded layer with '" + LayersConfigBuilder.EXCLUDE_PREFIX + "'. "
+            + "In order to un-exclude a layer already excluded in the current installation, prefix the layer with '"
+            + LayersConfigBuilder.REMOVE_EXCLUDE_PREFIX + "'.";
     String INSTALL_MODEL = "The layers model";
     String LEAVE_EXPLORATION = "Leave exploration";
     String LEAVE_STATE = "Leave provisioning state";

--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/CliErrors.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/CliErrors.java
@@ -39,6 +39,10 @@ public interface CliErrors {
         return failed("Add universe");
     }
 
+    static String cantExcludeLayer(String layer) {
+        return "Layer " + layer + " has been included, can't be excluded.";
+    }
+
     static String checkForUpdatesFailed() {
         return failed("Check for updates");
     }
@@ -288,6 +292,18 @@ public interface CliErrors {
 
     static String unknownDirectory(String dir) {
         return "Directory " + dir + " doesn't exist";
+    }
+
+    static String noExcludedLayers() {
+        return "No layer have been excluded in the current installation, can't remove layer exclusion.";
+    }
+
+    static String notDependencyLayer(String layer) {
+        return "Layer " + layer + " is not a dependency of the provisioned layers.";
+    }
+
+    static String notExcludedLayer(String layer) {
+        return "Layer " + layer + " has not been excluded.";
     }
 
     static String unknownFile(String absolutePath) {

--- a/docs/guide/tool/state.adoc
+++ b/docs/guide/tool/state.adoc
@@ -123,6 +123,20 @@ When installing layers, a custom configuration is generated.
 _install <[FPL|FPID] | [--file=<path to fp zip file>]> [--dir=<installation dir>] [--layers=<comma separated list of layers>] 
 [--config=<layers_model/configuration_name>]_
 
+In order to exclude an optional layer on which a layer from the list depends on, 
+prefix the excluded layer with '-'. In order to un-exclude a layer already excluded 
+in the current installation, prefix the layer with '+'.
+
+NB: When installing layers, the existing provisioned installation (if any) is updated with the set of layers.
+
+* If some layers to install are already installed, they are ignored.
+* If some layers to exclude are already excluded, they are ignored.
+* If some layers to install are excluded from the existing installation, they are first un-excluded and installed.
+* If some layers to exclude are included in the existing installation, the command will fail. You can only exclude not directly included layers.
+* If some layers to un-exclude are not excluded, the command will fail.
+* If some layers to exclude are not optional dependencies of the layers to install (or from already installed layers), the command will fail.
+You can only exclude layers that are optional dependencies.
+
 If no model name is provided, the CLI tries to identify the default model contained in the feature-pack.
 If no configuration name is provided, the <layers_model>.xml is used as the generated configuration file name.
 

--- a/maven-plugin/src/main/java/org/jboss/galleon/maven/plugin/ProvisionStateMojo.java
+++ b/maven-plugin/src/main/java/org/jboss/galleon/maven/plugin/ProvisionStateMojo.java
@@ -264,9 +264,9 @@ public class ProvisionStateMojo extends AbstractMojo {
             if (hasLayers) {
                 if (pluginOptions.isEmpty()) {
                     pluginOptions = Collections.
-                            singletonMap(Constants.OPTIONAL_PACKAGES, Constants.PASSIVE);
+                            singletonMap(Constants.OPTIONAL_PACKAGES, Constants.PASSIVE_PLUS);
                 } else if (!pluginOptions.containsKey(Constants.OPTIONAL_PACKAGES)) {
-                    pluginOptions.put(Constants.OPTIONAL_PACKAGES, Constants.PASSIVE);
+                    pluginOptions.put(Constants.OPTIONAL_PACKAGES, Constants.PASSIVE_PLUS);
                 }
             }
 


### PR DESCRIPTION
Issue https://issues.jboss.org/browse/GAL-296
* Allow to prefix a layer from the layers list with "-" to exclude it. Such layers are optional layer referenced from other provisioned layers.
* Allow to prefix a layer from the layers list with "+" to un-exclude it. Such layers should have been previously excluded.
* Added test and doc.

Issue https://issues.jboss.org/browse/GAL-297
* Changed the maven plugin default value to be passive+ when provisioning layers.