### PR TITLE
[GAL-278] Command for building is ./do.sh build, not ./do.sh package.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -166,5 +166,5 @@ The executable JAR will be built in `cli/target/galleon-cli.jar`
 There is also a convenience `do.sh` script in the root directory
 of the project. If executed w/o arguments, it'll build and launch the tool.
 
-`./do.sh package` will only build the tool.
+`./do.sh build` will only build the tool.
 `./do.sh run` will only launch the already built tool.


### PR DESCRIPTION
See #278. I assume it is only an issue with the documentation and build should be done with `./do.sh build`.