### PR TITLE
[GAL-309] For capability names if a parameter value is surrounded by …

### DIFF
--- a/core/src/main/java/org/jboss/galleon/runtime/CapabilityResolver.java
+++ b/core/src/main/java/org/jboss/galleon/runtime/CapabilityResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 Red Hat, Inc. and/or its affiliates
+ * Copyright 2016-2020 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,6 +25,7 @@ import java.util.List;
 import org.jboss.galleon.Errors;
 import org.jboss.galleon.ProvisioningException;
 import org.jboss.galleon.spec.CapabilitySpec;
+import org.jboss.galleon.util.StringUtils;
 
 /**
  * @author Alexey Loubyansky
@@ -147,6 +148,6 @@ public class CapabilityResolver {
         if(str.isEmpty()) {
             throw new ProvisioningException(Errors.illegalCapabilityElement(capSpec, str, capBuf.toString()));
         }
-        return str;
+        return StringUtils.stripSurrounding(str, '"');
     }
 }

--- a/core/src/main/java/org/jboss/galleon/util/StringUtils.java
+++ b/core/src/main/java/org/jboss/galleon/util/StringUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 Red Hat, Inc. and/or its affiliates
+ * Copyright 2016-2020 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -46,5 +46,29 @@ public class StringUtils {
         for(int i = 1; i < list.size(); ++i) {
             buf.append(',').append(list.get(i));
         }
+    }
+
+    /**
+     * Strings the surrounding character from the string.
+     * <p>
+     * If the string both starts with and ends with the character the value will be returned without the surrounding
+     * character. If the value does not both start and end with the character the value will be returned as-is.
+     * </p>
+     *
+     * @param value the value to strip the start and end character from if they exist
+     * @param c     the character to remove from the start and end of the value
+     *
+     * @return the value with the surrounding character removed if the value starts and ends with the character,
+     * otherwise the value is returned as-is.
+     */
+    public static String stripSurrounding(final String value, final char c) {
+        if (value.charAt(0) == c) {
+            final int len = value.length();
+            final int last = len - 1;
+            if (value.charAt(last) == c) {
+                return value.substring(1, last);
+            }
+        }
+        return value;
     }
 }


### PR DESCRIPTION
…quotes the surrounding quotes should be removed for the capability name.

https://issues.redhat.com/browse/GAL-309