### PR TITLE
[GAL-323] Add a skip configuration parameter to each MOJO.

### DIFF
--- a/maven-plugin/src/main/java/org/jboss/galleon/maven/plugin/CreateProducerMojo.java
+++ b/maven-plugin/src/main/java/org/jboss/galleon/maven/plugin/CreateProducerMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 Red Hat, Inc. and/or its affiliates
+ * Copyright 2016-2020 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -114,8 +114,20 @@ public class CreateProducerMojo extends AbstractMojo {
     @Parameter(required = true)
     private List<ChannelDescription> channels = Collections.emptyList();
 
+    /**
+     * Specifies whether creating the producer should be skipped.
+     *
+     * @since 4.2.6
+     */
+    @Parameter(defaultValue = "false", property = PropertyNames.SKIP)
+    private boolean skip;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
+        if (skip) {
+            getLog().info("Skipping the create-producer goal.");
+            return;
+        }
         try {
             createProducer();
         } catch (MavenUniverseException e) {

--- a/maven-plugin/src/main/java/org/jboss/galleon/maven/plugin/CreateProducersMojo.java
+++ b/maven-plugin/src/main/java/org/jboss/galleon/maven/plugin/CreateProducersMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 Red Hat, Inc. and/or its affiliates
+ * Copyright 2016-2020 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -86,8 +86,20 @@ public class CreateProducersMojo extends AbstractMojo {
     @Parameter(required = true)
     private List<ProducerDescription> producers;
 
+    /**
+     * Specifies whether the creating the producers should be skipped.
+     *
+     * @since 4.2.6
+     */
+    @Parameter(defaultValue = "false", property = PropertyNames.SKIP)
+    private boolean skip;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
+        if (skip) {
+            getLog().info("Skipping the create-producers goal.");
+            return;
+        }
         final MavenArtifact artifact = new MavenArtifact().setGroupId(groupId).setArtifactId(artifactId).setVersion(version);
         final MavenProducers installer = MavenProducers.getInstance(
                 SimplisticMavenRepoManager.getInstance(Paths.get(project.getBuild().getDirectory()).resolve("local-repo"),

--- a/maven-plugin/src/main/java/org/jboss/galleon/maven/plugin/CreateUniverseMojo.java
+++ b/maven-plugin/src/main/java/org/jboss/galleon/maven/plugin/CreateUniverseMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 Red Hat, Inc. and/or its affiliates
+ * Copyright 2016-2020 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -117,8 +117,20 @@ public class CreateUniverseMojo extends AbstractMojo {
     @Parameter(required = true)
     private List<ProducerSpec> producers = Collections.emptyList();
 
+    /**
+     * Specifies whether creating the Galleon universe should be skipped.
+     *
+     * @since 4.2.6
+     */
+    @Parameter(defaultValue = "false", property = PropertyNames.SKIP)
+    private boolean skip;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
+        if (skip) {
+            getLog().info("Skipping the create-universe goal.");
+            return;
+        }
 
         final MavenArtifact universeArtifact = new MavenArtifact()
                 .setGroupId(groupId)

--- a/maven-plugin/src/main/java/org/jboss/galleon/maven/plugin/FeaturePackInstallMojo.java
+++ b/maven-plugin/src/main/java/org/jboss/galleon/maven/plugin/FeaturePackInstallMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 Red Hat, Inc. and/or its affiliates
+ * Copyright 2016-2020 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -142,8 +142,20 @@ public class FeaturePackInstallMojo extends AbstractMojo {
     @Parameter(alias = "record-state", defaultValue = "true")
     private boolean recordState = true;
 
+    /**
+     * Specifies whether installing the feature pack should be skipped.
+     *
+     * @since 4.2.6
+     */
+    @Parameter(defaultValue = "false", property = PropertyNames.SKIP)
+    private boolean skip;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
+        if (skip) {
+            getLog().info("Skipping the install-feature-pack goal.");
+            return;
+        }
 
         FeaturePackLocation fpl = null;
         Path localPath = null;

--- a/maven-plugin/src/main/java/org/jboss/galleon/maven/plugin/PropertyNames.java
+++ b/maven-plugin/src/main/java/org/jboss/galleon/maven/plugin/PropertyNames.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016-2020 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.galleon.maven.plugin;
+
+/**
+ * The property names used for the MOJO parameters.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+interface PropertyNames {
+
+    String SKIP = "galleon.skip";
+}

--- a/maven-plugin/src/main/java/org/jboss/galleon/maven/plugin/ProvisionFileStateMojo.java
+++ b/maven-plugin/src/main/java/org/jboss/galleon/maven/plugin/ProvisionFileStateMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 Red Hat, Inc. and/or its affiliates
+ * Copyright 2016-2020 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -99,8 +99,20 @@ public class ProvisionFileStateMojo extends AbstractMojo {
     @Parameter(alias = "record-state", defaultValue = "true")
     private boolean recordState = true;
 
+    /**
+     * Specifies whether the provisioning should be skipped.
+     *
+     * @since 4.2.6
+     */
+    @Parameter(defaultValue = "false", property = PropertyNames.SKIP)
+    private boolean skip;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
+        if (skip) {
+            getLog().info("Skipping the provision-file goal.");
+            return;
+        }
         if (!provisioningFile.exists()) {
             throw new MojoExecutionException("Provisioning file " + provisioningFile + " doesn't exist.");
         }

--- a/maven-plugin/src/main/java/org/jboss/galleon/maven/plugin/ProvisionStateMojo.java
+++ b/maven-plugin/src/main/java/org/jboss/galleon/maven/plugin/ProvisionStateMojo.java
@@ -150,8 +150,20 @@ public class ProvisionStateMojo extends AbstractMojo {
     @Parameter(alias = "resolve-locals")
     private List<ResolveLocalItem> resolveLocals = Collections.emptyList();
 
+    /**
+     * Specifies whether the provisioning should be skipped.
+     *
+     * @since 4.2.6
+     */
+    @Parameter(defaultValue = "false", property = PropertyNames.SKIP)
+    private boolean skip;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
+        if (skip) {
+            getLog().info("Skipping the provision goal.");
+            return;
+        }
         if(featurePacks.isEmpty()) {
             throw new MojoExecutionException("No feature-packs to install.");
         }


### PR DESCRIPTION
https://issues.redhat.com/browse/GAL-323

Note I've added the `@Since 4.2.6` however if this doesn't make that release or we feel it should be in a 4.3 release let me know and I'll update it.

I feel this parameter is useful though. For example in WildFly we can skip provisioning servers for the test suite if the `-DskipTests` parameter is used.