### PR TITLE
Fix for GAL-326, GAV based FP breaks update

### DIFF
--- a/cli/src/main/java/org/jboss/galleon/cli/cmd/state/StateInfoUtil.java
+++ b/cli/src/main/java/org/jboss/galleon/cli/cmd/state/StateInfoUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 Red Hat, Inc. and/or its affiliates
+ * Copyright 2016-2020 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -629,7 +629,7 @@ public class StateInfoUtil {
     public static String formatChannel(FeaturePackLocation loc) {
         String channel = loc.getFrequency() == null ? loc.getChannel().getName() : loc.getChannel().getName()
                 + "/" + loc.getFrequency();
-        return (loc.getUniverse() == null ? "" : loc.getUniverse() + "@") + channel;
+        return (loc.getUniverse() == null ? "" : loc.getUniverse() + "@") + (channel == null ? "" : channel);
     }
 
     private static String buildOptionsTable(Set<ProvisioningOption> options) {

--- a/core/src/main/java/org/jboss/galleon/universe/Channel.java
+++ b/core/src/main/java/org/jboss/galleon/universe/Channel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 Red Hat, Inc. and/or its affiliates
+ * Copyright 2016-2020 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -50,7 +50,7 @@ public interface Channel {
         } catch(LatestVersionNotAvailableException e) {
             // that also means no update
         }
-        if (latestBuild != null && !(latestBuild.equals(fpl.getBuild()))) {
+        if (latestBuild != null && !latestBuild.isEmpty() && !(latestBuild.equals(fpl.getBuild()))) {
             updateRequest.setNewLocation(fpl.replaceBuild(latestBuild));
         }
         return updateRequest.buildPlan();


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/GAL-326
Maven is returning an empty string, we must filter it out. Fixed CLI display of null channel.