### PR TITLE
Fix for GAL-331, CLI fails to provision WildFly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,6 @@
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-artifact</artifactId>
-        <scope>provided</scope>
         <version>${version.org.apache.maven}</version>
       </dependency>
 

--- a/release_process.adoc
+++ b/release_process.adoc
@@ -7,6 +7,12 @@ First, make sure you don't have pending changes in your master branch.
 * `cd galleon`
 * `git checkout main`
 * `pull --rebase upstream main`
+* `mvn clean install`
+* Check that the cli starts, and can provision Wildfly: 
+** `./do.sh run`
+** `install wildfly --dir=foo`
+** `exit`
+** `rm -rf foo`
 * Update docs/* content to reference the new released version.
 * Update do.sh script to reference the new released version.
 * Commit the changes with message: `Update doc and script to X.X.X.Final`


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/GAL-331
* Removed invalid dependency scope.
* Updated release process doc to ensure CLI can provision wildfly.