### PR TITLE
[GAL-337] Handle 'false-conflicts' in upgrade diff

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -39,6 +39,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.jboss</groupId>
       <artifactId>staxmapper</artifactId>
     </dependency>

--- a/core/src/main/java/org/jboss/galleon/Constants.java
+++ b/core/src/main/java/org/jboss/galleon/Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 Red Hat, Inc. and/or its affiliates
+ * Copyright 2016-2022 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -80,4 +80,5 @@ public interface Constants {
     String FIRST_PROCESSED = "first-processed";
     String FAIL = "fail";
 
+    String PRINT_ONLY_CONFLICTS = "print-only-conflicts";
 }

--- a/core/src/main/java/org/jboss/galleon/ProvisioningManager.java
+++ b/core/src/main/java/org/jboss/galleon/ProvisioningManager.java
@@ -58,6 +58,8 @@ import org.jboss.galleon.xml.ProvisionedStateXmlParser;
 import org.jboss.galleon.xml.ProvisioningXmlParser;
 import org.jboss.galleon.xml.ProvisioningXmlWriter;
 
+import static org.jboss.galleon.Constants.PRINT_ONLY_CONFLICTS;
+
 /**
  *
  * @author Alexey Loubyansky
@@ -670,7 +672,7 @@ public class ProvisioningManager implements AutoCloseable {
             }
             Map<String, Boolean> undoTasks = Collections.emptyMap();
             if (fsDiff != null && !fsDiff.isEmpty()) {
-                undoTasks = FsDiff.replay(fsDiff, runtime.getStagedDir(), log);
+                undoTasks = FsDiff.replay(fsDiff, runtime.getStagedDir(), log, Boolean.parseBoolean(runtime.getProvisioningConfig().getOption(PRINT_ONLY_CONFLICTS)));
             }
 
             if(freshInstall) {

--- a/core/src/main/java/org/jboss/galleon/ProvisioningOption.java
+++ b/core/src/main/java/org/jboss/galleon/ProvisioningOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 Red Hat, Inc. and/or its affiliates
+ * Copyright 2016-2022 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -49,8 +49,13 @@ public class ProvisioningOption {
             .setBooleanValueSet()
             .build();
 
+    public static final ProvisioningOption PRINT_ONLY_CONFLICTS = ProvisioningOption.builder(Constants.PRINT_ONLY_CONFLICTS)
+           .setDefaultValue(Constants.TRUE)
+           .setBooleanValueSet()
+           .build();
+
     private static final List<ProvisioningOption> stdOptions = Arrays
-            .asList(new ProvisioningOption[] { IGNORE_NOT_EXCLUDED_LAYERS, OPTIONAL_PACKAGES, VERSION_CONVERGENCE });
+            .asList(new ProvisioningOption[] { IGNORE_NOT_EXCLUDED_LAYERS, OPTIONAL_PACKAGES, VERSION_CONVERGENCE, PRINT_ONLY_CONFLICTS});
 
     public static List<ProvisioningOption> getStandardList() {
         return stdOptions;

--- a/core/src/main/java/org/jboss/galleon/diff/FsDiff.java
+++ b/core/src/main/java/org/jboss/galleon/diff/FsDiff.java
@@ -66,7 +66,8 @@ public class FsDiff {
 
     private static final char REPLAY_SKIP = 'S';
     public static final char ADDED = '+';
-    public static final char MODIFIED = 'C'; // for conflict
+    public static final char CONFLICT = 'C'; // for conflict
+    public static final char MODIFIED = 'M';
     public static final char REMOVED = '-';
 
     public static final String CONFLICTS_WITH_THE_UPDATED_VERSION = "conflicts with the updated version";
@@ -114,7 +115,7 @@ public class FsDiff {
                 }
                 final FsEntry update = modified[1];
                 final Path target = home.resolve(update.getRelativePath());
-                char action = MODIFIED;
+                char action = CONFLICT;
                 String warning = null;
                 if(Files.exists(target)) {
                     final byte[] targetHash;
@@ -137,6 +138,8 @@ public class FsDiff {
                         }
                     } else if (modifiedPathConflict(update)) {
                         glnew(target);
+                    } else {
+                        action = MODIFIED;
                     }
                 } else if(modifiedPathNotPresent(update)) {
                     warning = HAS_BEEN_REMOVED_FROM_THE_UPDATED_VERSION;
@@ -184,13 +187,13 @@ public class FsDiff {
                     action = REPLAY_SKIP;
                 } else {
                     warning = MATCHES_THE_UPDATED_VERSION;
-                    action = MODIFIED;
+                    action = CONFLICT;
                 }
                 undoTasks = CollectionUtils.putLinked(undoTasks, added.getRelativePath(), true);
             } else if(addedPathConflict(added) && !added.isDir()) {
                 warning = CONFLICTS_WITH_THE_UPDATED_VERSION;
                 glnew(target);
-                action = MODIFIED;
+                action = CONFLICT;
             }
         }
         if (action != REPLAY_SKIP) {

--- a/core/src/test/java/org/jboss/galleon/test/FeaturePackRepoTestBase.java
+++ b/core/src/test/java/org/jboss/galleon/test/FeaturePackRepoTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 Red Hat, Inc. and/or its affiliates
+ * Copyright 2016-2022 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,7 +20,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import org.jboss.galleon.DefaultMessageWriter;
 import org.jboss.galleon.Errors;
+import org.jboss.galleon.MessageWriter;
 import org.jboss.galleon.ProvisioningException;
 import org.jboss.galleon.ProvisioningManager;
 import org.jboss.galleon.config.ProvisioningConfig;
@@ -87,11 +89,16 @@ public class FeaturePackRepoTestBase {
         return FeaturePackCreator.getInstance().addArtifactResolver(repo);
     }
 
+    protected MessageWriter getMessageWriter() {
+        return new DefaultMessageWriter();
+    }
+
     protected ProvisioningManager getPm() throws ProvisioningException {
         return ProvisioningManager.builder()
                 .addArtifactResolver(repo)
                 .setInstallationHome(installHome)
                 .setRecordState(recordState)
+                .setMessageWriter(getMessageWriter())
                 .build();
     }
 

--- a/docs/guide/tool/state.adoc
+++ b/docs/guide/tool/state.adoc
@@ -198,7 +198,7 @@ You can then use the listed options (if any) to customize your update command.
 
 ### Retrieving changes applied to an installation
 In order to visualize files you have added, removed or modified, use the command _get-changes [--dir=<installation>]_. +
-In the CLI output added files are prefixed by '+', removed ones by '-' and modified ones by 'C' (for conflict).
+In the CLI output added files are prefixed by '+', removed ones by '-' and modified ones by 'M'.
 
 ### Persisting changes applied to an installation
 Installed feature-packs optionally support persistence of changes into the provisioning configuration. As an example, 

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
         For example: <version.org.jboss.as.console>
     -->
     <version.adoc-maven-plugin-descriptor>1.0.0.Alpha3</version.adoc-maven-plugin-descriptor>
+    <version.assertj>3.23.1</version.assertj>
     <version.com.io7m.xom>1.2.10</version.com.io7m.xom>
     <version.com.mycila.license-maven-plugin>3.0</version.com.mycila.license-maven-plugin>
     <version.junit>4.13.1</version.junit>
@@ -314,6 +315,12 @@
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>${version.junit}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+        <version>${version.assertj}</version>
         <scope>test</scope>
       </dependency>
     </dependencies>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -36,6 +36,11 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.jboss.galleon</groupId>

--- a/testsuite/src/test/java/org/jboss/galleon/cli/ChangesTestCase.java
+++ b/testsuite/src/test/java/org/jboss/galleon/cli/ChangesTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 Red Hat, Inc. and/or its affiliates
+ * Copyright 2016-2022 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -86,14 +86,14 @@ public class ChangesTestCase {
         Path nf = p.getParent().relativize(newFile);
         Path f = p.getParent().relativize(file);
         assertTrue(cli.getOutput(), cli.getOutput().contains(" + " + nf));
-        assertTrue(cli.getOutput(), cli.getOutput().contains(" C " + f));
+        assertTrue(cli.getOutput(), cli.getOutput().contains(" M " + f));
 
         cli.execute("cd " + p);
         cli.execute("get-changes");
         nf = p.relativize(newFile);
         f = p.relativize(file);
         assertTrue(cli.getOutput(), cli.getOutput().contains(" + " + nf));
-        assertTrue(cli.getOutput(), cli.getOutput().contains(" C " + f));
+        assertTrue(cli.getOutput(), cli.getOutput().contains(" M " + f));
 
         cli.execute("cd " + root);
         cli.execute("get-changes");
@@ -101,7 +101,7 @@ public class ChangesTestCase {
         nf = root.relativize(newFile);
         f = root.relativize(file);
         assertTrue(cli.getOutput(), cli.getOutput().contains(" + " + nf));
-        assertTrue(cli.getOutput(), cli.getOutput().contains(" C " + f));
+        assertTrue(cli.getOutput(), cli.getOutput().contains(" M " + f));
 
         Files.delete(file);
 

--- a/testsuite/src/test/java/org/jboss/galleon/userchanges/test/UserChangesAfterInstallTestCase.java
+++ b/testsuite/src/test/java/org/jboss/galleon/userchanges/test/UserChangesAfterInstallTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 Red Hat, Inc. and/or its affiliates
+ * Copyright 2016-2022 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -124,7 +124,6 @@ public class UserChangesAfterInstallTestCase extends UserChangesTestBase {
         return newDirBuilder()
                 .addFile("prod1/p1.txt", "prod1 p1")
                 .addFile("prod1/p2.txt", "user")
-                .addFile("prod1/p2.txt.glnew", "prod1 p2")
                 .addDir("prod1/user")
                 .addFile("prod2/p1.txt", "prod2 p1")
                 .addFile("prod2/p2.txt", "prod2 p2")

--- a/testsuite/src/test/java/org/jboss/galleon/userchanges/test/UserChangesAfterUndoTestCase.java
+++ b/testsuite/src/test/java/org/jboss/galleon/userchanges/test/UserChangesAfterUndoTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 Red Hat, Inc. and/or its affiliates
+ * Copyright 2016-2022 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -56,12 +56,19 @@ public class UserChangesAfterUndoTestCase extends UserChangesTestBase {
                 .writeContent("prod1/p2.txt", "prod1 p2")
                 .getFeaturePack()
             .newPackage("p3")
-                .writeContent("prod1/p3.txt", "prod1 p3");
+                .writeContent("prod1/p3.txt", "prod1 p3")
+                .getFeaturePack()
+            .newPackage("common", true)
+               .writeContent("common.txt", "prod1");
 
         prod2 = newFpl("prod2", "1", "1.0.0.Final");
         creator.newFeaturePack(prod2.getFPID())
             .newPackage("p1", true)
-                .writeContent("prod2/p1.txt", "prod2 p1");
+                .writeContent("prod2/p1.txt", "prod2 p1")
+                .writeContent("prod2/p2.txt", "prod2 p2")
+                .getFeaturePack()
+           .newPackage("common", true)
+                .writeContent("common.txt", "prod2");
 
     }
 
@@ -71,6 +78,8 @@ public class UserChangesAfterUndoTestCase extends UserChangesTestBase {
         pm.install(prod2);
         writeContent("new.txt", "user");
         writeContent("prod1/p2.txt", "user");
+        writeContent("prod2/p2.txt", "user");
+        writeContent("common.txt", "user");
         recursiveDelete("prod1/p3.txt");
         mkdirs("prod1/user");
         pm.undo();
@@ -92,6 +101,7 @@ public class UserChangesAfterUndoTestCase extends UserChangesTestBase {
                         .addPackage("p1")
                         .addPackage("p2")
                         .addPackage("p3")
+                        .addPackage("common")
                         .build())
                 .build();
     }
@@ -101,8 +111,10 @@ public class UserChangesAfterUndoTestCase extends UserChangesTestBase {
         return newDirBuilder()
                 .addFile("prod1/p1.txt", "prod1 p1")
                 .addFile("prod1/p2.txt", "user")
-                .addFile("prod1/p2.txt.glnew", "prod1 p2")
                 .addFile("new.txt", "user")
+                .addFile("prod2/p2.txt", "user")
+                .addFile("common.txt", "user")
+                .addFile("common.txt.glnew", "prod1")
                 .addDir("prod1/user")
                 .build();
     }

--- a/testsuite/src/test/java/org/jboss/galleon/userchanges/test/UserChangesAfterUninstallTestCase.java
+++ b/testsuite/src/test/java/org/jboss/galleon/userchanges/test/UserChangesAfterUninstallTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 Red Hat, Inc. and/or its affiliates
+ * Copyright 2016-2022 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -56,12 +56,19 @@ public class UserChangesAfterUninstallTestCase extends UserChangesTestBase {
                 .writeContent("prod1/p2.txt", "prod1 p2")
                 .getFeaturePack()
             .newPackage("p3")
-                .writeContent("prod1/p3.txt", "prod1 p3");
+                .writeContent("prod1/p3.txt", "prod1 p3")
+                .getFeaturePack()
+            .newPackage("common", true)
+                .writeContent("common.txt", "prod1");
 
         prod2 = newFpl("prod2", "1", "1.0.0.Final");
         creator.newFeaturePack(prod2.getFPID())
             .newPackage("p1", true)
-                .writeContent("prod2/p1.txt", "prod2 p1");
+                .writeContent("prod2/p1.txt", "prod2 p1")
+                .writeContent("prod2/p2.txt", "prod2 p2")
+                .getFeaturePack()
+            .newPackage("common", true)
+                .writeContent("common.txt", "prod2");
 
     }
 
@@ -71,6 +78,8 @@ public class UserChangesAfterUninstallTestCase extends UserChangesTestBase {
         pm.install(prod2);
         writeContent("new.txt", "user");
         writeContent("prod1/p2.txt", "user");
+        writeContent("prod2/p2.txt", "user");
+        writeContent("common.txt", "user");
         recursiveDelete("prod1/p3.txt");
         mkdirs("prod1/user");
         pm.uninstall(prod2.getFPID());
@@ -92,6 +101,7 @@ public class UserChangesAfterUninstallTestCase extends UserChangesTestBase {
                         .addPackage("p1")
                         .addPackage("p2")
                         .addPackage("p3")
+                        .addPackage("common")
                         .build())
                 .build();
     }
@@ -101,8 +111,10 @@ public class UserChangesAfterUninstallTestCase extends UserChangesTestBase {
         return newDirBuilder()
                 .addFile("prod1/p1.txt", "prod1 p1")
                 .addFile("prod1/p2.txt", "user")
-                .addFile("prod1/p2.txt.glnew", "prod1 p2")
+                .addFile("prod2/p2.txt", "user")
                 .addFile("new.txt", "user")
+                .addFile("common.txt", "user")
+                .addFile("common.txt.glnew", "prod1")
                 .addDir("prod1/user")
                 .build();
     }

--- a/testsuite/src/test/java/org/jboss/galleon/userchanges/test/diff/UserChangesFullDiffTestCaseTestCase.java
+++ b/testsuite/src/test/java/org/jboss/galleon/userchanges/test/diff/UserChangesFullDiffTestCaseTestCase.java
@@ -14,7 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.galleon.userchanges.test;
+package org.jboss.galleon.userchanges.test.diff;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.jboss.galleon.ProvisioningDescriptionException;
 import org.jboss.galleon.ProvisioningException;
@@ -22,21 +27,18 @@ import org.jboss.galleon.ProvisioningManager;
 import org.jboss.galleon.config.FeaturePackConfig;
 import org.jboss.galleon.config.ProvisioningConfig;
 import org.jboss.galleon.creator.FeaturePackCreator;
+import org.jboss.galleon.diff.FsDiff;
 import org.jboss.galleon.state.ProvisionedFeaturePack;
 import org.jboss.galleon.state.ProvisionedState;
 import org.jboss.galleon.test.util.fs.state.DirState;
 import org.jboss.galleon.universe.FeaturePackLocation;
 import org.jboss.galleon.universe.MvnUniverse;
+import org.jboss.galleon.userchanges.test.UserChangesTestBase;
 
-/**
- *
- * @author Alexey Loubyansky
- */
-public class UserChangesAfterMultipleUpdatesTestCase extends UserChangesTestBase {
+public class UserChangesFullDiffTestCaseTestCase extends UserChangesTestBase {
 
     private FeaturePackLocation prod100;
     private FeaturePackLocation prod101;
-    private FeaturePackLocation prod200;
 
     @Override
     protected void createProducers(MvnUniverse universe) throws ProvisioningException {
@@ -59,9 +61,6 @@ public class UserChangesAfterMultipleUpdatesTestCase extends UserChangesTestBase
             .newPackage("p3")
                 .writeContent("prod1/p3.txt", "prod100 p3")
                 .getFeaturePack()
-            .newPackage("p4", true)
-                .writeContent("prod1/p4.txt", "prod100 p4")
-                .getFeaturePack()
             .newPackage("common", true)
                 .writeContent("common.txt", "prod100");
 
@@ -73,7 +72,7 @@ public class UserChangesAfterMultipleUpdatesTestCase extends UserChangesTestBase
                 .writeContent("prod1/p101.txt", "prod101 p1")
                 .getFeaturePack()
             .newPackage("p2")
-                .writeContent("prod1/p2.txt", "prod101 p2")
+                .writeContent("prod1/p2.txt", "prod100 p2")
                 .getFeaturePack()
             .newPackage("p3")
                 .writeContent("prod1/p3.txt", "prod101 p3")
@@ -84,31 +83,32 @@ public class UserChangesAfterMultipleUpdatesTestCase extends UserChangesTestBase
             .newPackage("common", true)
                 .writeContent("common.txt", "prod101");
 
-        prod200 = newFpl("prod2", "1", "1.0.0.Final");
-        creator.newFeaturePack(prod200.getFPID())
-            .newPackage("p1", true)
-                .writeContent("prod2/p1.txt", "prod200 p1");
-
     }
 
     @Override
     protected void testPm(ProvisioningManager pm) throws ProvisioningException {
-        pm.install(prod100);
+        final HashMap<String, String> options = getPMOptions();
+        pm.install(prod100, options);
+        writeContent("new.txt", "user");
         writeContent("prod1/p1.txt", "user");
         writeContent("prod1/p2.txt", "user");
         writeContent("prod1/p3.txt", "user");
-        pm.install(prod101);
-        writeContent("prod1/p3.txt", "user2");
-        pm.install(prod200);
+        writeContent("prod1/p4.txt", "user");
+        pm.install(prod101, options);
     }
 
 
     @Override
     protected ProvisioningConfig provisionedConfig() throws ProvisioningDescriptionException {
-        return ProvisioningConfig.builder()
-                .addFeaturePackDep(FeaturePackConfig.builder(prod101).build())
-                .addFeaturePackDep(FeaturePackConfig.builder(prod200).build())
-                .build();
+        final ProvisioningConfig.Builder builder = ProvisioningConfig.builder()
+           .addFeaturePackDep(FeaturePackConfig.builder(prod101).build());
+
+        final HashMap<String, String> options = getPMOptions();
+        for (Map.Entry<String, String> option : options.entrySet()) {
+            builder.addOption(option.getKey(), option.getValue());
+        }
+
+        return builder.build();
     }
 
     @Override
@@ -121,10 +121,12 @@ public class UserChangesAfterMultipleUpdatesTestCase extends UserChangesTestBase
                         .addPackage("p4")
                         .addPackage("common")
                         .build())
-                .addFeaturePack(ProvisionedFeaturePack.builder(prod200.getFPID())
-                        .addPackage("p1")
-                        .build())
                 .build();
+    }
+
+    protected HashMap<String, String> getPMOptions() {
+        final HashMap<String, String> options = new HashMap<>();
+        return options;
     }
 
     @Override
@@ -132,11 +134,24 @@ public class UserChangesAfterMultipleUpdatesTestCase extends UserChangesTestBase
         return newDirBuilder()
                 .addFile("prod1/p1.txt", "user")
                 .addFile("prod1/p2.txt", "user")
-                .addFile("prod1/p3.txt", "user2")
-                .addFile("prod1/p4.txt", "prod101 p4")
+                .addFile("prod1/p3.txt", "user")
+                .addFile("prod1/p3.txt.glnew", "prod101 p3")
+                .addFile("prod1/p4.txt", "user")
+                .addFile("prod1/p4.txt.glnew", "prod101 p4")
                 .addFile("prod1/p101.txt", "prod101 p1")
-                .addFile("prod2/p1.txt", "prod200 p1")
                 .addFile("common.txt", "prod101")
+                .addFile("new.txt", "user")
                 .build();
+    }
+
+    @Override
+    protected List<String> expectedDiff() {
+        return Arrays.asList(
+           FsDiff.formatMessage(FsDiff.ADDED, "new.txt", null),
+           FsDiff.formatMessage(FsDiff.MODIFIED, "prod1/p4.txt", FsDiff.CONFLICTS_WITH_THE_UPDATED_VERSION),
+           FsDiff.formatMessage(FsDiff.ADDED, "prod1/p1.txt", FsDiff.HAS_BEEN_REMOVED_FROM_THE_UPDATED_VERSION),
+           FsDiff.formatMessage(FsDiff.MODIFIED, "prod1/p2.txt", null),
+           FsDiff.formatMessage(FsDiff.MODIFIED, "prod1/p3.txt", FsDiff.HAS_CHANGED_IN_THE_UPDATED_VERSION)
+        );
     }
 }

--- a/testsuite/src/test/java/org/jboss/galleon/userchanges/test/diff/UserChangesFullDiffTestCaseTestCase.java
+++ b/testsuite/src/test/java/org/jboss/galleon/userchanges/test/diff/UserChangesFullDiffTestCaseTestCase.java
@@ -148,10 +148,10 @@ public class UserChangesFullDiffTestCaseTestCase extends UserChangesTestBase {
     protected List<String> expectedDiff() {
         return Arrays.asList(
            FsDiff.formatMessage(FsDiff.ADDED, "new.txt", null),
-           FsDiff.formatMessage(FsDiff.MODIFIED, "prod1/p4.txt", FsDiff.CONFLICTS_WITH_THE_UPDATED_VERSION),
+           FsDiff.formatMessage(FsDiff.CONFLICT, "prod1/p4.txt", FsDiff.CONFLICTS_WITH_THE_UPDATED_VERSION),
            FsDiff.formatMessage(FsDiff.ADDED, "prod1/p1.txt", FsDiff.HAS_BEEN_REMOVED_FROM_THE_UPDATED_VERSION),
            FsDiff.formatMessage(FsDiff.MODIFIED, "prod1/p2.txt", null),
-           FsDiff.formatMessage(FsDiff.MODIFIED, "prod1/p3.txt", FsDiff.HAS_CHANGED_IN_THE_UPDATED_VERSION)
+           FsDiff.formatMessage(FsDiff.CONFLICT, "prod1/p3.txt", FsDiff.HAS_CHANGED_IN_THE_UPDATED_VERSION)
         );
     }
 }

--- a/testsuite/src/test/java/org/jboss/galleon/userchanges/test/diff/UserChangesOnlyConflictsDiffTestCase.java
+++ b/testsuite/src/test/java/org/jboss/galleon/userchanges/test/diff/UserChangesOnlyConflictsDiffTestCase.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016-2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.galleon.userchanges.test.diff;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+import org.jboss.galleon.Constants;
+import org.jboss.galleon.diff.FsDiff;
+
+public class UserChangesOnlyConflictsDiffTestCase extends UserChangesFullDiffTestCaseTestCase {
+
+    @Override
+    protected HashMap<String, String> getPMOptions() {
+        final HashMap<String, String> options = new HashMap<>();
+        options.put(Constants.PRINT_ONLY_CONFLICTS, "true");
+        return options;
+    }
+
+    @Override
+    protected List<String> expectedDiff() {
+        return Arrays.asList(
+           FsDiff.formatMessage(FsDiff.MODIFIED, "prod1/p4.txt", FsDiff.CONFLICTS_WITH_THE_UPDATED_VERSION),
+           FsDiff.formatMessage(FsDiff.ADDED, "prod1/p1.txt", FsDiff.HAS_BEEN_REMOVED_FROM_THE_UPDATED_VERSION),
+           FsDiff.formatMessage(FsDiff.MODIFIED, "prod1/p3.txt", FsDiff.HAS_CHANGED_IN_THE_UPDATED_VERSION)
+        );
+    }
+}

--- a/testsuite/src/test/java/org/jboss/galleon/userchanges/test/diff/UserChangesOnlyConflictsDiffTestCase.java
+++ b/testsuite/src/test/java/org/jboss/galleon/userchanges/test/diff/UserChangesOnlyConflictsDiffTestCase.java
@@ -35,9 +35,9 @@ public class UserChangesOnlyConflictsDiffTestCase extends UserChangesFullDiffTes
     @Override
     protected List<String> expectedDiff() {
         return Arrays.asList(
-           FsDiff.formatMessage(FsDiff.MODIFIED, "prod1/p4.txt", FsDiff.CONFLICTS_WITH_THE_UPDATED_VERSION),
+           FsDiff.formatMessage(FsDiff.CONFLICT, "prod1/p4.txt", FsDiff.CONFLICTS_WITH_THE_UPDATED_VERSION),
            FsDiff.formatMessage(FsDiff.ADDED, "prod1/p1.txt", FsDiff.HAS_BEEN_REMOVED_FROM_THE_UPDATED_VERSION),
-           FsDiff.formatMessage(FsDiff.MODIFIED, "prod1/p3.txt", FsDiff.HAS_CHANGED_IN_THE_UPDATED_VERSION)
+           FsDiff.formatMessage(FsDiff.CONFLICT, "prod1/p3.txt", FsDiff.HAS_CHANGED_IN_THE_UPDATED_VERSION)
         );
     }
 }


### PR DESCRIPTION
Proposal for https://issues.redhat.com/browse/GAL-337

False-conflicts don't generate .glnew files
Added 'print-only-conflicts' option to allow displaying only real conflicts