### PR TITLE
Fix for GAL-341, Allow to persist the provisioning config provided as input

### DIFF
--- a/core/src/main/java/org/jboss/galleon/Constants.java
+++ b/core/src/main/java/org/jboss/galleon/Constants.java
@@ -71,6 +71,8 @@ public interface Constants {
     // OPTIONS
     String IGNORE_NOT_EXCLUDED_LAYERS = "ignore-not-excluded-layers";
 
+    String STORE_INPUT_PROVISIONING_CONFIG = "store-input-provisioning-config";
+
     String OPTIONAL_PACKAGES = "optional-packages";
     String ALL = "all";
     String NONE = "none";

--- a/core/src/main/java/org/jboss/galleon/ProvisioningOption.java
+++ b/core/src/main/java/org/jboss/galleon/ProvisioningOption.java
@@ -49,13 +49,19 @@ public class ProvisioningOption {
             .setBooleanValueSet()
             .build();
 
+    public static final ProvisioningOption STORE_INPUT_PROVISIONING_CONFIG = ProvisioningOption.builder(Constants.STORE_INPUT_PROVISIONING_CONFIG)
+            .setDefaultValue(Constants.FALSE)
+            .setBooleanValueSet()
+            .build();
+
     public static final ProvisioningOption PRINT_ONLY_CONFLICTS = ProvisioningOption.builder(Constants.PRINT_ONLY_CONFLICTS)
            .setDefaultValue(Constants.TRUE)
            .setBooleanValueSet()
            .build();
 
     private static final List<ProvisioningOption> stdOptions = Arrays
-            .asList(new ProvisioningOption[] { IGNORE_NOT_EXCLUDED_LAYERS, OPTIONAL_PACKAGES, VERSION_CONVERGENCE, PRINT_ONLY_CONFLICTS});
+            .asList(new ProvisioningOption[] { IGNORE_NOT_EXCLUDED_LAYERS, OPTIONAL_PACKAGES, VERSION_CONVERGENCE, PRINT_ONLY_CONFLICTS,
+                STORE_INPUT_PROVISIONING_CONFIG});
 
     public static List<ProvisioningOption> getStandardList() {
         return stdOptions;

--- a/core/src/main/java/org/jboss/galleon/layout/ProvisioningLayout.java
+++ b/core/src/main/java/org/jboss/galleon/layout/ProvisioningLayout.java
@@ -324,6 +324,7 @@ public class ProvisioningLayout<F extends FeaturePackLayout> implements AutoClos
     private final FeaturePackLayoutFactory<F> fpFactory;
     private final Handle handle;
     private ProvisioningConfig config;
+    private final ProvisioningConfig originalConfig;
     private Map<String, String> options = Collections.emptyMap();
 
     private Map<ProducerSpec, FeaturePackLocation> resolvedVersions;
@@ -346,6 +347,7 @@ public class ProvisioningLayout<F extends FeaturePackLayout> implements AutoClos
         this.layoutFactory = layoutFactory;
         this.fpFactory = fpFactory;
         this.config = config;
+        this.originalConfig = config;
         this.handle = layoutFactory.createHandle();
         if(config.hasFeaturePackDeps()) {
             initBuiltInOptions(config, Collections.emptyMap());
@@ -366,6 +368,7 @@ public class ProvisioningLayout<F extends FeaturePackLayout> implements AutoClos
         this.layoutFactory = layoutFactory;
         this.fpFactory = fpFactory;
         this.config = config;
+        this.originalConfig = config;
         this.handle = layoutFactory.createHandle();
         if(config.hasFeaturePackDeps()) {
             initBuiltInOptions(config, extraOptions);
@@ -402,6 +405,7 @@ public class ProvisioningLayout<F extends FeaturePackLayout> implements AutoClos
         this.layoutFactory = other.layoutFactory;
         this.fpFactory = fpFactory;
         this.config = other.config;
+        this.originalConfig = other.originalConfig;
         this.options = CollectionUtils.clone(other.options);
         this.systemPaths = other.systemPaths;
 
@@ -786,6 +790,16 @@ public class ProvisioningLayout<F extends FeaturePackLayout> implements AutoClos
             }
         }
         return p;
+    }
+
+    public ProvisioningConfig getOriginalConfig() throws ProvisioningDescriptionException {
+        // Use the options that have been set in the rewritten config
+       ProvisioningConfig.Builder builder = ProvisioningConfig.builder(originalConfig);
+       for (String opt : originalConfig.getOptions().keySet()) {
+           builder.removeOption(opt);
+       }
+       builder.addOptions(config.getOptions());
+       return builder.build();
     }
 
     public List<F> getOrderedFeaturePacks() {

--- a/core/src/main/java/org/jboss/galleon/runtime/ProvisioningRuntime.java
+++ b/core/src/main/java/org/jboss/galleon/runtime/ProvisioningRuntime.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Set;
 
 import javax.xml.stream.XMLStreamException;
+import org.jboss.galleon.Constants;
 
 import org.jboss.galleon.Errors;
 import org.jboss.galleon.MessageWriter;
@@ -272,7 +273,9 @@ public class ProvisioningRuntime implements FeaturePackSet<FeaturePackRuntime>, 
         if(recordState) {
             // save the config
             try {
-                ProvisioningXmlWriter.getInstance().write(config, PathsUtils.getProvisioningXml(stagedDir));
+                ProvisioningConfig cfg = Boolean.parseBoolean(config.getOption(Constants.STORE_INPUT_PROVISIONING_CONFIG)) ?
+                        layout.getOriginalConfig() : config;
+                ProvisioningXmlWriter.getInstance().write(cfg, PathsUtils.getProvisioningXml(stagedDir));
             } catch (XMLStreamException | IOException e) {
                 throw new FeaturePackInstallException(Errors.writeFile(PathsUtils.getProvisioningXml(stagedDir)), e);
             }

--- a/docs/guide/provisioning-options/index.adoc
+++ b/docs/guide/provisioning-options/index.adoc
@@ -44,6 +44,7 @@ Provisioning options can be provided by the core provisioning mechanism itself a
 |Name |Purpose |Value set
 |ignore-not-excluded-layers |<<_excluding_layers_from_configuration_models,Suppresses the error when layers configured to be excluded would not have otherwise been installed>> |`false` _(default)_, `true`
 |optional-packages |<<_feature_pack_original_effective_package_set,Optional package dependencies inclusion policy>> |`all` _(default)_, `none`, `passive`, `passive+`
+|store-input-provisioning-config |<<_storing_input_provisioning_config,Store the provisioning config received as input in the generated .galleon/provisioning.xml file>> |`false` _(default)_, `true`
 |version-convergence |<<_dependency_version_convergence,Disables or enables the dependency version convergence>> | `first-processed` _(default)_, `fail`
 |===
 


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/GAL-341