### PR TITLE
[GAL-345] Record system paths only if provisioning is set up to record state

### DIFF
--- a/core/src/main/java/org/jboss/galleon/runtime/ProvisioningRuntime.java
+++ b/core/src/main/java/org/jboss/galleon/runtime/ProvisioningRuntime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 Red Hat, Inc. and/or its affiliates
+ * Copyright 2016-2023 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -286,13 +286,14 @@ public class ProvisioningRuntime implements FeaturePackSet<FeaturePackRuntime>, 
             } catch (XMLStreamException | IOException e) {
                 throw new FeaturePackInstallException(Errors.writeFile(PathsUtils.getProvisionedStateXml(stagedDir)), e);
             }
-        }
-        boolean exportPath = Boolean.parseBoolean(layout.getOptionValue(Constants.EXPORT_SYSTEM_PATHS));
-        if (exportPath) {
-            try {
-                layout.getSystemPaths().store(stagedDir);
-            } catch (IOException ex) {
-                throw new ProvisioningException(ex);
+
+            boolean exportPath = Boolean.parseBoolean(layout.getOptionValue(Constants.EXPORT_SYSTEM_PATHS));
+            if (exportPath) {
+                try {
+                    layout.getSystemPaths().store(stagedDir);
+                } catch (IOException ex) {
+                    throw new ProvisioningException(ex);
+                }
             }
         }
         emptyStagedDir = null;


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/GAL-345
