### PR TITLE
[GAL-355] Explicitly cast the null parameter in newFileSystem to Clas…

### DIFF
--- a/common-api/src/main/java/org/jboss/galleon/util/ZipUtils.java
+++ b/common-api/src/main/java/org/jboss/galleon/util/ZipUtils.java
@@ -149,6 +149,7 @@ public class ZipUtils {
      * @throws IOException  in case of a failure
      */
      public static FileSystem newFileSystem(Path path) throws IOException {
-         return FileSystems.newFileSystem(path, null);
+         // The case here is explicitly done for Java 13+ where there is a newFileSystem(Path, Map) method as well.
+         return FileSystems.newFileSystem(path, (ClassLoader) null);
      }
 }


### PR DESCRIPTION
…sLoader to avoid ambiguity in Java 13+.

https://issues.redhat.com/browse/GAL-355