### PR TITLE
Fix for GAL-390, Rebuilt family member dependency must use FPL (if feature-pack producer is an FPL)

### DIFF
--- a/core/src/main/java/org/jboss/galleon/layout/ProvisioningLayout.java
+++ b/core/src/main/java/org/jboss/galleon/layout/ProvisioningLayout.java
@@ -1325,12 +1325,12 @@ public class ProvisioningLayout<F extends FeaturePackLayout> implements AutoClos
                             }
                         }
                         if(result.isDifferentMember()) {
-                            if(rebuilder.hasTransitiveFeaturePackDep(dep.getLocation().getProducer())) {
+                            if(rebuilder.hasTransitiveFeaturePackDep(fpDep.getFPID().getLocation().getProducer())) {
                                 rebuilder.addFeaturePackDepAllowMultiple(fpSpec.originOf(result.getOriginalDependency().getLocation().getProducer()),
-                                FeaturePackConfig.transitiveBuilder(dep.getLocation()).init(dep).build());
+                                FeaturePackConfig.transitiveBuilder(fpDep.getFPID().getLocation()).init(dep).build());
                             } else {
                                 rebuilder.addFeaturePackDep(fpSpec.originOf(result.getOriginalDependency().getLocation().getProducer()),
-                                FeaturePackConfig.transitiveBuilder(dep.getLocation()).init(dep).build());
+                                FeaturePackConfig.transitiveBuilder(fpDep.getFPID().getLocation()).init(dep).build());
                             }
                         } else {
                             rebuilder.addFeaturePackDep(fpSpec.originOf(result.getOriginalDependency().getLocation().getProducer()),
@@ -1402,15 +1402,15 @@ public class ProvisioningLayout<F extends FeaturePackLayout> implements AutoClos
                         }
 
                         if(result.isDifferentMember()) {
-                            if (rebuilder.hasFeaturePackDep(dep.getLocation().getProducer()) || rebuilder.hasTransitiveFeaturePackDep(dep.getLocation().getProducer())) {
+                            if (rebuilder.hasFeaturePackDep(fpDep.getFPID().getLocation().getProducer()) || rebuilder.hasTransitiveFeaturePackDep(fpDep.getFPID().getLocation().getProducer())) {
                                 rebuilder.addFeaturePackDepAllowMultiple(fpSpec.originOf(result.getOriginalDependency().getLocation().getProducer()),
-                                    FeaturePackConfig.builder(dep.getLocation()).init(dep).build());
+                                    FeaturePackConfig.builder(fpDep.getFPID().getLocation()).init(dep).build());
                                 if (rebuilder.hasTransitiveFeaturePackDep(dep.getLocation().getProducer())) {
                                     transitiveToIgnore.add(fpDep.getFPID().getLocation().getProducer());
                                 }
                             } else {
                                 rebuilder.addFeaturePackDep(fpSpec.originOf(result.getOriginalDependency().getLocation().getProducer()),
-                                    FeaturePackConfig.builder(dep.getLocation()).init(dep).build());
+                                    FeaturePackConfig.builder(fpDep.getFPID().getLocation()).init(dep).build());
                             }
                         } else {
                           rebuilder.addFeaturePackDep(fpSpec.originOf(result.getOriginalDependency().getLocation().getProducer()),

--- a/testsuite/src/test/java/org/jboss/galleon/layout/family/test/FPLFamilyExcludePackageTransitiveTestCase.java
+++ b/testsuite/src/test/java/org/jboss/galleon/layout/family/test/FPLFamilyExcludePackageTransitiveTestCase.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2016-2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.galleon.layout.family.test;
+
+import java.nio.file.Path;
+import org.jboss.galleon.ProvisioningDescriptionException;
+import org.jboss.galleon.ProvisioningException;
+import org.jboss.galleon.config.ConfigModel;
+import org.jboss.galleon.config.FeaturePackConfig;
+import org.jboss.galleon.config.ProvisioningConfig;
+import org.jboss.galleon.creator.FeaturePackBuilder;
+import org.jboss.galleon.creator.FeaturePackCreator;
+import org.jboss.galleon.repo.RepositoryArtifactResolver;
+import org.jboss.galleon.spec.FeaturePackSpec.Family;
+import org.jboss.galleon.state.ProvisionedFeaturePack;
+import org.jboss.galleon.state.ProvisionedState;
+import org.jboss.galleon.universe.FeaturePackLocation;
+import org.jboss.galleon.universe.MvnUniverse;
+import org.jboss.galleon.universe.ProvisionFromUniverseTestBase;
+import org.jboss.galleon.universe.maven.repo.SimplisticMavenRepoManager;
+import org.jboss.galleon.xml.ProvisionedConfigBuilder;
+
+public class FPLFamilyExcludePackageTransitiveTestCase extends ProvisionFromUniverseTestBase {
+
+    private FeaturePackLocation fpl1;
+    private FeaturePackLocation fpl2;
+    private FeaturePackLocation fpl3;
+
+    @Override
+    protected RepositoryArtifactResolver initRepoManager(Path repoHome) {
+        return SimplisticMavenRepoManager.getInstance(repoHome);
+    }
+    @Override
+    protected void createProducers(MvnUniverse universe) throws ProvisioningException {
+        universe.createProducer("ee10-gal", 2);
+        universe.createProducer("ee11-gal", 2);
+        universe.createProducer("cloud-gal", 2);
+    }
+    @Override
+    protected void createFeaturePacks(FeaturePackCreator creator) throws ProvisioningDescriptionException {
+        fpl1 = newFpl("ee10-gal", "1", "1.0.0.Final");
+        FeaturePackBuilder builder1 = creator.newFeaturePack(fpl1.getFPID())
+                .newPackage("p3", true)
+                .addDependency("p4", true)
+                .getFeaturePack().
+                newPackage("p4").getFeaturePack();
+        builder1.setFamily(Family.fromString("family1:specific1"));
+
+        fpl2 = newFpl("ee11-gal", "1", "1.0.0.Final");
+        FeaturePackBuilder builder2 = creator.newFeaturePack(fpl2.getFPID())
+                .newPackage("p3", true)
+                .addDependency("p4", true)
+                .getFeaturePack().
+                newPackage("p4").getFeaturePack().
+                newPackage("p5").getFeaturePack();
+        builder2.setFamily(Family.fromString("family1:specific1"));
+
+        fpl3 = newFpl("cloud-gal", "1", "1.0.0.Final");
+        FeaturePackBuilder builder3 = creator.newFeaturePack(fpl3.getFPID());
+        builder3.addDependency("foo-origin", FeaturePackConfig.builder(toMavenCoordsFpl(fpl1)).
+                setAllowedFamily("family1:specific1").setInheritPackages(false).excludePackage("p4").includePackage("p5").build());
+        builder3.newPackage("local", true)
+                .addDependency("p4")
+                .getFeaturePack().
+                newPackage("p4").getFeaturePack();
+    }
+
+    @Override
+    protected ProvisioningConfig provisioningConfig() throws ProvisioningException {
+        return ProvisioningConfig.builder()
+                .addFeaturePackDep(FeaturePackConfig.transitiveBuilder(fpl2).build())
+                .addFeaturePackDep(FeaturePackConfig.builder(fpl3).build())
+                .addConfig(ConfigModel.builder("model1", "name1").build()).build();
+    }
+
+    @Override
+    protected ProvisionedState provisionedState() throws ProvisioningException {
+        return ProvisionedState.builder()
+                .addFeaturePack(ProvisionedFeaturePack.builder(fpl2.getFPID())
+                        .addPackage("p5")
+                        .build())
+                .addFeaturePack(ProvisionedFeaturePack.builder(fpl3.getFPID())
+                        .addPackage("local")
+                        .addPackage("p4")
+                        .build())
+                .addConfig(ProvisionedConfigBuilder.builder()
+                        .setModel("model1")
+                        .setName("name1")
+                        .build())
+                .build();
+    }
+
+}

--- a/testsuite/src/test/java/org/jboss/galleon/layout/family/test/FeaturePackFamilyExcludePackageTransitiveTestCase.java
+++ b/testsuite/src/test/java/org/jboss/galleon/layout/family/test/FeaturePackFamilyExcludePackageTransitiveTestCase.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2016-2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.galleon.layout.family.test;
+
+import java.nio.file.Path;
+import org.jboss.galleon.ProvisioningDescriptionException;
+import org.jboss.galleon.ProvisioningException;
+import org.jboss.galleon.config.ConfigModel;
+import org.jboss.galleon.config.FeaturePackConfig;
+import org.jboss.galleon.config.ProvisioningConfig;
+import org.jboss.galleon.creator.FeaturePackBuilder;
+import org.jboss.galleon.creator.FeaturePackCreator;
+import org.jboss.galleon.repo.RepositoryArtifactResolver;
+import org.jboss.galleon.spec.FeaturePackSpec.Family;
+import org.jboss.galleon.state.ProvisionedFeaturePack;
+import org.jboss.galleon.state.ProvisionedState;
+import org.jboss.galleon.universe.FeaturePackLocation;
+import org.jboss.galleon.universe.MvnUniverse;
+import org.jboss.galleon.universe.ProvisionFromUniverseTestBase;
+import org.jboss.galleon.universe.maven.repo.SimplisticMavenRepoManager;
+import org.jboss.galleon.xml.ProvisionedConfigBuilder;
+
+public class FeaturePackFamilyExcludePackageTransitiveTestCase extends ProvisionFromUniverseTestBase {
+
+    private FeaturePackLocation fpl1;
+    private FeaturePackLocation fpl2;
+    private FeaturePackLocation fpl3;
+
+    @Override
+    protected RepositoryArtifactResolver initRepoManager(Path repoHome) {
+        return SimplisticMavenRepoManager.getInstance(repoHome);
+    }
+
+    @Override
+    protected void createFeaturePacks(FeaturePackCreator creator) throws ProvisioningDescriptionException {
+        fpl1 = FeaturePackLocation.fromString("org.jboss.galleon.test:dep-family-fp1:1.0.0.Final");
+        FeaturePackBuilder builder1 = creator.newFeaturePack(fpl1.getFPID())
+                .newPackage("p3", true)
+                .addDependency("p4", true)
+                .getFeaturePack().
+                newPackage("p4").getFeaturePack();
+        builder1.setFamily(Family.fromString("family1:specific1"));
+
+        fpl2 = FeaturePackLocation.fromString("org.jboss.galleon.test:dep-family-fp2:1.0.0.Final");
+        FeaturePackBuilder builder2 = creator.newFeaturePack(fpl2.getFPID())
+                .newPackage("p3", true)
+                .addDependency("p4", true)
+                .getFeaturePack().
+                newPackage("p4").getFeaturePack().
+                newPackage("p5").getFeaturePack();
+        builder2.setFamily(Family.fromString("family1:specific1"));
+
+        fpl3 = FeaturePackLocation.fromString("org.jboss.galleon.test:fp1:1.0.0.Final");
+        FeaturePackBuilder builder3 = creator.newFeaturePack(fpl3.getFPID());
+        builder3.addDependency("foo-origin", FeaturePackConfig.builder(toMavenCoordsFpl(fpl1)).setAllowedFamily("family1:specific1").
+                setInheritPackages(false).excludePackage("p4").includePackage("p5").build());
+        builder3.newPackage("local", true)
+                .addDependency("p4")
+                .getFeaturePack().
+                newPackage("p4").getFeaturePack();
+    }
+
+    @Override
+    protected ProvisioningConfig provisioningConfig() throws ProvisioningException {
+        return ProvisioningConfig.builder()
+                .addFeaturePackDep(FeaturePackConfig.transitiveBuilder(fpl2).build())
+                .addFeaturePackDep(FeaturePackConfig.builder(fpl3).build())
+                .addConfig(ConfigModel.builder("model1", "name1").build()).build();
+    }
+
+    @Override
+    protected ProvisionedState provisionedState() throws ProvisioningException {
+        return ProvisionedState.builder()
+                .addFeaturePack(ProvisionedFeaturePack.builder(fpl2.getFPID())
+                        .addPackage("p5")
+                        .build())
+                .addFeaturePack(ProvisionedFeaturePack.builder(fpl3.getFPID())
+                        .addPackage("local")
+                        .addPackage("p4")
+                        .build())
+                .addConfig(ProvisionedConfigBuilder.builder()
+                        .setModel("model1")
+                        .setName("name1")
+                        .build())
+                .build();
+    }
+
+    @Override
+    protected void createProducers(MvnUniverse universe) throws ProvisioningException {
+    }
+}


### PR DESCRIPTION
ISSUE: https://redhat.atlassian.net/browse/GAL-390